### PR TITLE
Add iOS WKWebView Sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To provide feedback, please file an issue.
 
 - [Automated Moderation and Sentiment Analysis of Chat with the Amazon Chime SDK](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/moderated-chat-and-sentiment-analysis) - Creates a chat application with automated moderation, message effects, and sentiment analysis
 
+- [iOS WkWebView Sample](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/iOS-WKWebView-sample) - Demonstrates how to join a WebRTC-based meeting application, like the [Amazon Chime JS SDK Serverless Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless), from within a WKWebView in iOS. 
+
 ## Resources
 
 - [Amazon Chime SDK Overview](https://aws.amazon.com/chime/chime-sdk/)

--- a/apps/iOS-WKWebView-sample/.gitignore
+++ b/apps/iOS-WKWebView-sample/.gitignore
@@ -1,0 +1,4 @@
+## User settings
+xcuserdata/
+.build/
+playground.xcworkspace

--- a/apps/iOS-WKWebView-sample/README.md
+++ b/apps/iOS-WKWebView-sample/README.md
@@ -1,0 +1,22 @@
+# Amazon Chime SDK WKWebView Sample
+
+## Summary
+
+This sample shows how to run a WebRTC based meeting application inside of an iOS WKWebView. Prior to iOS 14.3, WKWebViews did not support WebRTC, meaning WKWebViews were not able to access WebRTC APIs. iOS 14.3 released support for WebRTC in WKWebViews - allowing developers to run WebRTC-based applications in a WKWebView. The sample itself is a bare-bones iOS app that loads a WKWebView, which then navigates to a specified URL.
+
+### Pre-requisites:
+- XCode 12.3+ installed on your machine
+
+### Deploy a Chime SDK for Javascript Meeting Demo
+If you'd like to try joining a WebRTC meeting demo from within a WKWebView in iOS, you first need a meeting demo running in a browser so that when you load the WKWebView it can navigate to this meeting demo URL. Follow the instructions for the [Amazon Chime JS SDK Serverless Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless) in order to deploy a meeting demo.
+
+After you've deployed a meeting demo URL, take note of the meeting demo URL that was outputted to your terminal as part of the last step of deploying the [Amazon Chime SDK for Javascript Serverless Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless). Take the meeting demo URL, and replace the variable `url` in `./AppConfiguration.swift` with the value of the meeting demo URL. 
+
+For example:
+```
+struct AppConfiguration {
+    static let url = "https://xxxx.execute-api.us-east-1.amazonaws.com/Prod/"
+}
+```
+
+You can now build and run the iOS application.  

--- a/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.pbxproj
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.pbxproj
@@ -1,0 +1,356 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AB0109822639FCCD00F39AB0 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0109812639FCCD00F39AB0 /* HomeViewController.swift */; };
+		AB0109852639FCCD00F39AB0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AB0109832639FCCD00F39AB0 /* Main.storyboard */; };
+		AB0109872639FCD000F39AB0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB0109862639FCD000F39AB0 /* Assets.xcassets */; };
+		AB01098A2639FCD000F39AB0 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AB0109882639FCD000F39AB0 /* LaunchScreen.storyboard */; };
+		AB0109B92639FE4700F39AB0 /* WkWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0109B82639FE4700F39AB0 /* WkWebViewController.swift */; };
+		AB2F0633264B339C00F68923 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2F0632264B339C00F68923 /* AppConfiguration.swift */; };
+		AB6EDCEF264C633600E41625 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6EDCEE264C633500E41625 /* SceneDelegate.swift */; };
+		AB6EDCF3264C634500E41625 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6EDCF2264C634500E41625 /* AppDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		AB01097A2639FCCD00F39AB0 /* WkWebView Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WkWebView Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB0109812639FCCD00F39AB0 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		AB0109842639FCCD00F39AB0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		AB0109862639FCD000F39AB0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		AB0109892639FCD000F39AB0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		AB01098B2639FCD000F39AB0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AB0109B82639FE4700F39AB0 /* WkWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WkWebViewController.swift; sourceTree = "<group>"; };
+		AB2F0632264B339C00F68923 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
+		AB6EDCEE264C633500E41625 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		AB6EDCF2264C634500E41625 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AB0109772639FCCD00F39AB0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AB0109712639FCCD00F39AB0 = {
+			isa = PBXGroup;
+			children = (
+				AB01097C2639FCCD00F39AB0 /* WkWebView Demo */,
+				AB01097B2639FCCD00F39AB0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AB01097B2639FCCD00F39AB0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AB01097A2639FCCD00F39AB0 /* WkWebView Demo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		AB01097C2639FCCD00F39AB0 /* WkWebView Demo */ = {
+			isa = PBXGroup;
+			children = (
+				AB6EDCEE264C633500E41625 /* SceneDelegate.swift */,
+				AB6EDCF2264C634500E41625 /* AppDelegate.swift */,
+				AB0109812639FCCD00F39AB0 /* HomeViewController.swift */,
+				AB0109832639FCCD00F39AB0 /* Main.storyboard */,
+				AB0109862639FCD000F39AB0 /* Assets.xcassets */,
+				AB0109882639FCD000F39AB0 /* LaunchScreen.storyboard */,
+				AB01098B2639FCD000F39AB0 /* Info.plist */,
+				AB0109B82639FE4700F39AB0 /* WkWebViewController.swift */,
+				AB2F0632264B339C00F68923 /* AppConfiguration.swift */,
+			);
+			path = "WkWebView Demo";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AB0109792639FCCD00F39AB0 /* WkWebView Demo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AB0109A42639FCD000F39AB0 /* Build configuration list for PBXNativeTarget "WkWebView Demo" */;
+			buildPhases = (
+				AB0109762639FCCD00F39AB0 /* Sources */,
+				AB0109772639FCCD00F39AB0 /* Frameworks */,
+				AB0109782639FCCD00F39AB0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "WkWebView Demo";
+			productName = "WkWebView Demo";
+			productReference = AB01097A2639FCCD00F39AB0 /* WkWebView Demo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AB0109722639FCCD00F39AB0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					AB0109792639FCCD00F39AB0 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = AB0109752639FCCD00F39AB0 /* Build configuration list for PBXProject "WkWebView Demo" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AB0109712639FCCD00F39AB0;
+			productRefGroup = AB01097B2639FCCD00F39AB0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AB0109792639FCCD00F39AB0 /* WkWebView Demo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AB0109782639FCCD00F39AB0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AB01098A2639FCD000F39AB0 /* LaunchScreen.storyboard in Resources */,
+				AB0109872639FCD000F39AB0 /* Assets.xcassets in Resources */,
+				AB0109852639FCCD00F39AB0 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AB0109762639FCCD00F39AB0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AB6EDCEF264C633600E41625 /* SceneDelegate.swift in Sources */,
+				AB2F0633264B339C00F68923 /* AppConfiguration.swift in Sources */,
+				AB0109822639FCCD00F39AB0 /* HomeViewController.swift in Sources */,
+				AB6EDCF3264C634500E41625 /* AppDelegate.swift in Sources */,
+				AB0109B92639FE4700F39AB0 /* WkWebViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		AB0109832639FCCD00F39AB0 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AB0109842639FCCD00F39AB0 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		AB0109882639FCD000F39AB0 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AB0109892639FCD000F39AB0 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		AB0109A22639FCD000F39AB0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AB0109A32639FCD000F39AB0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AB0109A52639FCD000F39AB0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "WkWebView Demo/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "amazonchimesdk.WkWebView-Demo";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AB0109A62639FCD000F39AB0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "WkWebView Demo/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "amazonchimesdk.WkWebView-Demo";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AB0109752639FCCD00F39AB0 /* Build configuration list for PBXProject "WkWebView Demo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB0109A22639FCD000F39AB0 /* Debug */,
+				AB0109A32639FCD000F39AB0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AB0109A42639FCD000F39AB0 /* Build configuration list for PBXNativeTarget "WkWebView Demo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB0109A52639FCD000F39AB0 /* Debug */,
+				AB0109A62639FCD000F39AB0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AB0109722639FCCD00F39AB0 /* Project object */;
+}

--- a/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/xcshareddata/xcschemes/WkWebView Demo.xcscheme
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/xcshareddata/xcschemes/WkWebView Demo.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB0109792639FCCD00F39AB0"
+               BuildableName = "WkWebView Demo.app"
+               BlueprintName = "WkWebView Demo"
+               ReferencedContainer = "container:WkWebView Demo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB6EDCF8264C63C200E41625"
+               BuildableName = "WkWebView DemoUITests.xctest"
+               BlueprintName = "WkWebView DemoUITests"
+               ReferencedContainer = "container:WkWebView Demo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB0109792639FCCD00F39AB0"
+            BuildableName = "WkWebView Demo.app"
+            BlueprintName = "WkWebView Demo"
+            ReferencedContainer = "container:WkWebView Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB0109792639FCCD00F39AB0"
+            BuildableName = "WkWebView Demo.app"
+            BlueprintName = "WkWebView Demo"
+            ReferencedContainer = "container:WkWebView Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/AppConfiguration.swift
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/AppConfiguration.swift
@@ -1,0 +1,13 @@
+//
+//  AppConfiguration.swift
+//  WkWebView Demo
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: MIT-0
+//
+
+import Foundation
+
+struct AppConfiguration {
+    static let url = "YOUR_SERVER_URL"
+}

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/AppDelegate.swift
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/AppDelegate.swift
@@ -1,0 +1,30 @@
+//
+//  AppDelegate.swift
+//  WkWebView Demo
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: MIT-0
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_: UIApplication,
+                     didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
+    {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_: UIApplication,
+                     configurationForConnecting connectingSceneSession: UISceneSession,
+                     options _: UIScene.ConnectionOptions) -> UISceneConfiguration
+    {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+}

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/Assets.xcassets/Contents.json
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/Base.lproj/LaunchScreen.storyboard
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/Base.lproj/Main.storyboard
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/Base.lproj/Main.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Home View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="HomeViewController" customModule="WkWebView_Demo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="142" y="85"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/HomeViewController.swift
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/HomeViewController.swift
@@ -1,0 +1,92 @@
+//
+//  HomeViewController.swift
+//  WkWebView Demo
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: MIT-0
+//
+
+import AVFoundation
+import UIKit
+import WebKit
+
+class HomeViewController: UIViewController {
+    private let button: UIButton = {
+        let button = UIButton()
+        button.setTitle("Go to WebView", for: .normal)
+        button.backgroundColor = .link
+        button.setTitleColor(.white, for: .normal)
+        return button
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(didTapbutton), for: .touchUpInside)
+        view.addSubview(button)
+        button.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        button.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+    }
+
+    override func viewDidAppear(_: Bool) {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized: // The user has previously granted access to the camera.
+            return
+        case .notDetermined: // The user has not yet been asked for camera access.
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                if granted {
+                    return
+                } else {
+                    self.presentCameraPermissionDeniedAlert()
+                }
+            }
+        case .denied,
+             .restricted: // The user has previously denied access.
+            presentCameraPermissionDeniedAlert()
+        }
+
+        switch AVAudioSession.sharedInstance().recordPermission {
+        case AVAudioSessionRecordPermission.granted:
+            return
+        case AVAudioSessionRecordPermission.denied:
+            presentMicrophonePermissionDeniedAlert()
+        case AVAudioSessionRecordPermission.undetermined:
+            // Request to record audio
+            AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                if granted {
+                    return
+                } else {
+                    self.presentMicrophonePermissionDeniedAlert()
+                }
+            }
+        }
+    }
+
+    @objc private func didTapbutton() {
+        let meetingURL = AppConfiguration.url
+        guard let url = URL(string: meetingURL) else {
+            return
+        }
+        let webViewVC = WkWebViewController(url: url, title: "WebView")
+        let navVC = UINavigationController(rootViewController: webViewVC)
+        present(navVC, animated: true)
+    }
+
+    func presentAlert(title: String, message: String, acceptText: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: acceptText, style: .default, handler: nil))
+        present(alert, animated: true)
+    }
+
+    func presentCameraPermissionDeniedAlert() {
+        presentAlert(title: "Access to Camera Denied",
+                     message: "Check Settings to make sure Camera access is enabled for this application.",
+                     acceptText: "OK")
+    }
+
+    func presentMicrophonePermissionDeniedAlert() {
+        presentAlert(title: "Access to Microphone Denied",
+                     message: "Check Settings to make sure Camera access is enabled for this application.",
+                     acceptText: "OK")
+    }
+}

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/Info.plist
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/Info.plist
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>The app requires microphone permission for video conferencing</string>
+	<key>NSCameraUsageDescription</key>
+	<string>The app requires camera permission for video conferencing</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+		<key>NSAllowsArbitraryLoadsForMedia</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/SceneDelegate.swift
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/SceneDelegate.swift
@@ -1,0 +1,20 @@
+//
+//  SceneDelegate.swift
+//  WkWebView Demo
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: MIT-0
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene,
+               willConnectTo _: UISceneSession,
+               options _: UIScene.ConnectionOptions)
+    {
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+}

--- a/apps/iOS-WKWebView-sample/WkWebView Demo/WkWebViewController.swift
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo/WkWebViewController.swift
@@ -1,0 +1,46 @@
+//
+//  WkWebViewController.swift
+//  WkWebView Demo
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: MIT-0
+//
+
+import UIKit
+import WebKit
+
+class WkWebViewController: UIViewController {
+    private let url: URL
+
+    let webView: WKWebView = {
+        let preferences = WKWebpagePreferences()
+        let configuration = WKWebViewConfiguration()
+        configuration.allowsInlineMediaPlayback = true
+        configuration.allowsPictureInPictureMediaPlayback = true
+        configuration.defaultWebpagePreferences = preferences
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        return webView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(webView)
+        webView.load(URLRequest(url: url))
+    }
+
+    init(url: URL, title: String) {
+        self.url = url
+        super.init(nibName: nil, bundle: nil)
+        self.title = title
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        webView.frame = view.bounds
+    }
+}


### PR DESCRIPTION
Issue #:

Description of changes:
Adds a iOS WKWebView sample iOS application. The sample is a basic iOS application that opens a generic WKWebView from iOS WebKit. The builder must supply a WebRTC based meeting application url before building the application so that the WebView will load the meeting application. This application is built on iOS 14.4, but should work for 14.3+, since WKWebviews suport WebRTC after iOS 14.3.

This was reviewed and approved by two members of the mobile team.

Testing
Provided a meeting demo url, and then built the application. I ran on a simulator and on my own device. To run on my own device, I provided a personal developer account to sign the application before building.

How did you test these changes?
Join a Chime based meeting from within a wkwebview. Confirm that audio/video are working as expected with multiple attendees.

Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
N/a

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.