### PR TITLE
[Chat] Minor css changes to the auth option in chat demo

### DIFF
--- a/apps/chat/src/containers/loginWithCredentialExchangeService/LoginWithCredentialExchangeService.jsx
+++ b/apps/chat/src/containers/loginWithCredentialExchangeService/LoginWithCredentialExchangeService.jsx
@@ -6,6 +6,7 @@ import {
   Textarea,
   Input,
   Button,
+  Heading,
 } from 'amazon-chime-sdk-component-library-react';
 
 import './LoginWithCredentialExchangeService.css';
@@ -29,12 +30,12 @@ const LoginWithCredentialExchangeService = (props) => {
 
   return (
     <div>
-      <p
+      <Heading
         css="font-size: 0.875rem !important; line-height: 3rem !important;"
         level="2"
       >
         Enter your Identity Token (JWT, PASETO, custom, etc):
-      </p>
+      </Heading>
       <form onSubmit={onSubmit} className="signin-form">
         <div className="input-container">
           <Textarea

--- a/apps/chat/src/views/Signin/index.jsx
+++ b/apps/chat/src/views/Signin/index.jsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT-0
 
 import React, {useState, setState} from 'react';
-import {Heading, Grid, Cell, Flex} from 'amazon-chime-sdk-component-library-react';
+import {Heading, Grid, Cell, Flex, Select} from 'amazon-chime-sdk-component-library-react';
 import { useTheme } from 'styled-components';
 import LoginWithCognito from '../../containers/loginWithCognito/LoginWithCognito';
 import LoginWithCredentialExchangeService from '../../containers/loginWithCredentialExchangeService/LoginWithCredentialExchangeService';
@@ -47,15 +47,21 @@ const Signin = () => {
         <Cell gridArea="main">
           <Flex className="signin-container" layout="stack">
             <Heading
-                css="font-size: 1.1875rem; line-height: 4rem;"
-                level="1"
+              css="font-size: 1.1875rem; line-height: 2rem;"
+              level="5"
             >
-              {signInMessage} <select name="signinProvider"
-                                      id="signinProvider"
-                                      onChange={e => updateSigninProvider(e.target.value)}>
-              <option value="cognito">Cognito User Pools</option>
-              <option value="ces">Credential Exchange Service</option>
-            </select>
+              {signInMessage}
+              <Select
+                name="signinProvider"
+                id="signinProvider"
+                value={signinProvider}
+                options={[
+                  { value: 'cognito', label: 'Cognito User Pools' },
+                  { value: 'ces', label: 'Credential Exchange Service' },
+                ]}
+                aria-label="sign in option"
+                onChange={e => updateSigninProvider(e.target.value)}
+              />
             </Heading>
             {provider}
           </Flex>


### PR DESCRIPTION
**Description of changes:**
Minor css update so that the auth option selection on the chat demo sign in screen is consistent with other fields.

**Testing**

1. How did you test these changes? Launched the app and verify that it was rendered correctly.
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? Yes, chat app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.