### PR TITLE
Add XCUITest to iOS WKWebview Demo

### DIFF
--- a/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.pbxproj
+++ b/apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj/project.pbxproj
@@ -15,7 +15,18 @@
 		AB2F0633264B339C00F68923 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2F0632264B339C00F68923 /* AppConfiguration.swift */; };
 		AB6EDCEF264C633600E41625 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6EDCEE264C633500E41625 /* SceneDelegate.swift */; };
 		AB6EDCF3264C634500E41625 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6EDCF2264C634500E41625 /* AppDelegate.swift */; };
+		AB7E4FEF2673FCEE00E6351A /* WkWebView_DemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7E4FEE2673FCEE00E6351A /* WkWebView_DemoUITests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		AB7E4FF12673FCEE00E6351A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AB0109722639FCCD00F39AB0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AB0109792639FCCD00F39AB0;
+			remoteInfo = "WkWebView Demo";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		AB01097A2639FCCD00F39AB0 /* WkWebView Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WkWebView Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -28,10 +39,20 @@
 		AB2F0632264B339C00F68923 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		AB6EDCEE264C633500E41625 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		AB6EDCF2264C634500E41625 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		AB7E4FEC2673FCEE00E6351A /* WkWebView DemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "WkWebView DemoUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB7E4FEE2673FCEE00E6351A /* WkWebView_DemoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WkWebView_DemoUITests.swift; sourceTree = "<group>"; };
+		AB7E4FF02673FCEE00E6351A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		AB0109772639FCCD00F39AB0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AB7E4FE92673FCEE00E6351A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -45,6 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				AB01097C2639FCCD00F39AB0 /* WkWebView Demo */,
+				AB7E4FED2673FCEE00E6351A /* WkWebView DemoUITests */,
 				AB01097B2639FCCD00F39AB0 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -53,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				AB01097A2639FCCD00F39AB0 /* WkWebView Demo.app */,
+				AB7E4FEC2673FCEE00E6351A /* WkWebView DemoUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -71,6 +94,15 @@
 				AB2F0632264B339C00F68923 /* AppConfiguration.swift */,
 			);
 			path = "WkWebView Demo";
+			sourceTree = "<group>";
+		};
+		AB7E4FED2673FCEE00E6351A /* WkWebView DemoUITests */ = {
+			isa = PBXGroup;
+			children = (
+				AB7E4FEE2673FCEE00E6351A /* WkWebView_DemoUITests.swift */,
+				AB7E4FF02673FCEE00E6351A /* Info.plist */,
+			);
+			path = "WkWebView DemoUITests";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -93,6 +125,24 @@
 			productReference = AB01097A2639FCCD00F39AB0 /* WkWebView Demo.app */;
 			productType = "com.apple.product-type.application";
 		};
+		AB7E4FEB2673FCEE00E6351A /* WkWebView DemoUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AB7E4FF32673FCEE00E6351A /* Build configuration list for PBXNativeTarget "WkWebView DemoUITests" */;
+			buildPhases = (
+				AB7E4FE82673FCEE00E6351A /* Sources */,
+				AB7E4FE92673FCEE00E6351A /* Frameworks */,
+				AB7E4FEA2673FCEE00E6351A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AB7E4FF22673FCEE00E6351A /* PBXTargetDependency */,
+			);
+			name = "WkWebView DemoUITests";
+			productName = "WkWebView DemoUITests";
+			productReference = AB7E4FEC2673FCEE00E6351A /* WkWebView DemoUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -104,6 +154,10 @@
 				TargetAttributes = {
 					AB0109792639FCCD00F39AB0 = {
 						CreatedOnToolsVersion = 12.4;
+					};
+					AB7E4FEB2673FCEE00E6351A = {
+						CreatedOnToolsVersion = 12.4;
+						TestTargetID = AB0109792639FCCD00F39AB0;
 					};
 				};
 			};
@@ -121,6 +175,7 @@
 			projectRoot = "";
 			targets = (
 				AB0109792639FCCD00F39AB0 /* WkWebView Demo */,
+				AB7E4FEB2673FCEE00E6351A /* WkWebView DemoUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -133,6 +188,13 @@
 				AB01098A2639FCD000F39AB0 /* LaunchScreen.storyboard in Resources */,
 				AB0109872639FCD000F39AB0 /* Assets.xcassets in Resources */,
 				AB0109852639FCCD00F39AB0 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AB7E4FEA2673FCEE00E6351A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,7 +213,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AB7E4FE82673FCEE00E6351A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AB7E4FEF2673FCEE00E6351A /* WkWebView_DemoUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AB7E4FF22673FCEE00E6351A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AB0109792639FCCD00F39AB0 /* WkWebView Demo */;
+			targetProxy = AB7E4FF12673FCEE00E6351A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		AB0109832639FCCD00F39AB0 /* Main.storyboard */ = {
@@ -206,6 +284,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -268,6 +347,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -296,6 +376,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "WkWebView Demo/Info.plist";
@@ -305,6 +386,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "amazonchimesdk.WkWebView-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -315,6 +397,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "WkWebView Demo/Info.plist";
@@ -324,8 +407,47 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "amazonchimesdk.WkWebView-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		AB7E4FF42673FCEE00E6351A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "WkWebView DemoUITests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "amazonchimesdk.WkWebView-DemoUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "WkWebView Demo";
+			};
+			name = Debug;
+		};
+		AB7E4FF52673FCEE00E6351A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "WkWebView DemoUITests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "amazonchimesdk.WkWebView-DemoUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "WkWebView Demo";
 			};
 			name = Release;
 		};
@@ -346,6 +468,15 @@
 			buildConfigurations = (
 				AB0109A52639FCD000F39AB0 /* Debug */,
 				AB0109A62639FCD000F39AB0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AB7E4FF32673FCEE00E6351A /* Build configuration list for PBXNativeTarget "WkWebView DemoUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB7E4FF42673FCEE00E6351A /* Debug */,
+				AB7E4FF52673FCEE00E6351A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/iOS-WKWebView-sample/WkWebView DemoUITests/Info.plist
+++ b/apps/iOS-WKWebView-sample/WkWebView DemoUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/apps/iOS-WKWebView-sample/WkWebView DemoUITests/WkWebView_DemoUITests.swift
+++ b/apps/iOS-WKWebView-sample/WkWebView DemoUITests/WkWebView_DemoUITests.swift
@@ -1,0 +1,49 @@
+//
+//  WkWebView_DemoUITests.swift
+//  WkWebView DemoUITests
+//
+//
+
+import XCTest
+
+class WkWebViewDemoUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testJoinMeeting() throws {
+        // Launch the application
+        let app = XCUIApplication()
+        app.launch()
+        
+        // Navigate to the WebView
+        app.buttons["Go to WebView"].tap()
+        let webView = app.webViews
+        
+        // Fill out the meeting form
+        _ = webView.textFields.element(boundBy: 0).waitForExistence(timeout: 10)
+        let meetingTitleField = webView.textFields.element(boundBy: 0);
+        meetingTitleField.tap()
+        let meetingTitle = UUID().uuidString
+        meetingTitleField.typeText(meetingTitle)
+        let nameField = webView.textFields.element(boundBy: 1)
+        nameField.tap()
+        let attendeeName = UUID().uuidString
+        nameField.typeText(attendeeName)
+        app.toolbars.buttons["Done"].tap()
+        webView.buttons["Continue"].tap()
+        
+        // Allow the getUserMedia device permissions request
+        _ = app.alerts.element.waitForExistence(timeout: 10)
+        app.alerts.element.buttons["Allow"].tap()
+        
+        // Join the meeting
+        _ = webView.buttons["Join"].waitForExistence(timeout: 10)
+        webView.buttons["Join"].tap()
+        
+        // Verify that we're in the meeting
+        XCTAssertTrue(webView.buttons["Toggle microphone"].exists)
+        XCTAssertTrue(webView.buttons["Toggle camera"].exists)
+    }
+}


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Add XCUITest to the iOS WKWebView Demo. This test will be run as a Github Action test in the Chime SDK for Javascript repository. The test only works when there is a valid hosted Chime SDK meeting url in the AppConfiguration.swift file. The test will load the meeting url in the WKWebview and verify that the meeting can be joined. 

**Testing**

1. How did you test these changes?
Ran the tests locally and verified the tests pass. 

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
The iOS WKWebview Demo is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.