### PR TITLE
Add remote roster actions(mute/unmute/kick out) to meeting demo

### DIFF
--- a/apps/meeting/src/components/RosterAttendeeWrapper.tsx
+++ b/apps/meeting/src/components/RosterAttendeeWrapper.tsx
@@ -1,13 +1,17 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import {
   RosterAttendee,
-  useAttendeeStatus
+  useAttendeeStatus,
+  PopOverItem,
+  useMeetingManager
 } from 'amazon-chime-sdk-component-library-react';
 import VideoStreamMetrics from '../containers/VideoStreamMetrics';
+import routes from '../constants/routes';
 
 interface Props {
   /** The Chime attendee ID */
@@ -16,11 +20,82 @@ interface Props {
 
 const RosterAttendeeWrapper: React.FC<Props> = ({ attendeeId }) => {
   const { videoEnabled } = useAttendeeStatus(attendeeId);
+  
+  const meetingManager = useMeetingManager();
+  const history = useHistory();
+
+  const sendMessage = async (topic: string, data: string, attendeeId: String) => {
+    const DATA_MESSAGE_LIFETIME_MS = 30000;
+  
+    const payload = {
+      data: data,
+      attendeeId: attendeeId || ''
+    };
+  
+    meetingManager.audioVideo &&
+      meetingManager.audioVideo.realtimeSendDataMessage(topic, payload, DATA_MESSAGE_LIFETIME_MS);
+  }
+
+  //Subscribe to receive data messages, customize this based on the need by allowing only certain roles to perform the operations
+  const realtimeSubscribeToReceiveDataMessage = async () => {
+    meetingManager.audioVideo?.realtimeSubscribeToReceiveDataMessage("RosterAttendeeActions", async (data) => {
+        const receivedData = (data && data.json()) || {};
+        const senderId = receivedData.attendeeId;
+        const type = receivedData.data;
+        if(senderId === meetingManager.meetingSession?.configuration.credentials?.attendeeId || '') {
+          if ((type === 'UNMUTE') && meetingManager.audioVideo?.realtimeIsLocalAudioMuted()) {
+            //use this to allow admin to unmute muted participants
+            //meetingManager.audioVideo?.realtimeUnmuteLocalAudio();
+          } else if(type === 'MUTE' && !meetingManager.audioVideo?.realtimeIsLocalAudioMuted()) {
+            meetingManager.audioVideo?.realtimeMuteLocalAudio();
+            //use this to restrict attendees unmuting themselves once muted by admin/other participants
+            //meetingManager.audioVideo?.realtimeSetCanUnmuteLocalAudio(false);
+          } else if(type === 'KICK_OUT') {
+            meetingManager.audioVideo?.stop();
+            meetingManager.audioVideo?.stopContentShare();
+            meetingManager.leave();
+            history.push(routes.HOME);
+          }
+        }
+      });
+
+      meetingManager.audioVideo?.realtimeSubscribeToReceiveDataMessage("RosterActions", async (data) => {
+        const receivedData = (data && data.json()) || {};
+        const type = receivedData.data;
+        
+        if ((type === 'UNMUTEALL') && meetingManager.audioVideo?.realtimeIsLocalAudioMuted()) {
+          meetingManager.audioVideo?.realtimeUnmuteLocalAudio();
+        } else if(type === 'MUTEALL' && !meetingManager.audioVideo?.realtimeIsLocalAudioMuted()) {
+          meetingManager.audioVideo?.realtimeMuteLocalAudio();
+        }
+      });
+  };
+
+  useEffect(() => {
+    realtimeSubscribeToReceiveDataMessage();
+  },[]);
+
   return (
     <RosterAttendee
       attendeeId={attendeeId}
       menu={
-        videoEnabled ? <VideoStreamMetrics attendeeId={attendeeId} /> : null
+        <><PopOverItem
+          children={<span>Kick Out</span>}
+          onClick={() => {
+            sendMessage("RosterAttendeeActions", "KICK_OUT", attendeeId);
+          } } />
+          <PopOverItem
+            children={<span>Mute</span>}
+            onClick={() => {
+              sendMessage("RosterAttendeeActions", "MUTE", attendeeId);
+            }} />
+          <PopOverItem
+            children={<span>Umnute</span>}
+            onClick={() => { 
+              sendMessage("RosterAttendeeActions", "UNMUTE", attendeeId);
+            }} />
+            {videoEnabled ? <VideoStreamMetrics attendeeId={attendeeId} /> : null}
+        </>
       }
     />
   );

--- a/apps/meeting/src/containers/MeetingRoster.tsx
+++ b/apps/meeting/src/containers/MeetingRoster.tsx
@@ -6,7 +6,9 @@ import {
   Roster,
   RosterHeader,
   RosterGroup,
-  useRosterState
+  useRosterState,
+  PopOverItem,
+  useMeetingManager
 } from 'amazon-chime-sdk-component-library-react';
 
 import { useNavigation } from '../providers/NavigationProvider';
@@ -16,6 +18,7 @@ const MeetingRoster = () => {
   const { roster } = useRosterState();
   const [filter, setFilter] = useState('');
   const { closeRoster } = useNavigation();
+  const meetingManager = useMeetingManager();
 
   let attendees = Object.values(roster);
 
@@ -34,6 +37,17 @@ const MeetingRoster = () => {
     return <RosterAttendeeWrapper key={chimeAttendeeId} attendeeId={chimeAttendeeId} />;
   });
 
+  const sendMessage = async (topic: string, data: string) => {
+    const DATA_MESSAGE_LIFETIME_MS = 30000;
+  
+    const payload = {
+      data: data,
+    };
+  
+    meetingManager.audioVideo &&
+      meetingManager.audioVideo.realtimeSendDataMessage(topic, payload, DATA_MESSAGE_LIFETIME_MS);
+  }
+
   return (
     <Roster className="roster">
       <RosterHeader
@@ -42,6 +56,18 @@ const MeetingRoster = () => {
         onClose={closeRoster}
         title="Present"
         badge={attendees.length}
+        menu={
+          <><PopOverItem
+            children={<span>Mute All</span>}
+            onClick={() => {
+              sendMessage("RosterActions", "MUTEALL");
+            } } />
+            <PopOverItem
+              children={<span>Unmute All</span>}
+              onClick={() => {
+                sendMessage("RosterActions", "UNMUTEALL");
+              }} /></>
+        }
       />
       <RosterGroup>{attendeeItems}</RosterGroup>
     </Roster>


### PR DESCRIPTION
**Issue #:** Remote attendee actions

**Description of changes:**
I see a lot of requests for sample code for mute/unmute functionality using data messages. Implemented a sample code which gives developers an idea to implement event based actions using Chime SDK

**Testing**

1. How did you test these changes? Manual verification of the meeting demo to test the mute, kick out functionality
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
React meeting demo application can be used to test the changes.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.