### PR TITLE
Added a Android WebView sample demo

### DIFF
--- a/apps/Android-WebView-sample/.gitignore
+++ b/apps/Android-WebView-sample/.gitignore
@@ -1,0 +1,5 @@
+/.gradle/
+/.idea/
+/app/build/
+/local.properties
+.DS_Store

--- a/apps/Android-WebView-sample/README.md
+++ b/apps/Android-WebView-sample/README.md
@@ -1,0 +1,22 @@
+# Amazon Chime SDK WKWebView Sample
+
+## Summary
+
+This sample shows how to run a WebRTC based meeting application inside of an Android Chromium WebView. The sample itself is a bare-bones Android app that loads a Chromium WebView, which then navigates to a URL that is specified in the `./app/java/AppConfig.kt` file. Currently Android Chromium WebView [does not support grabbing](https://bugs.chromium.org/p/chromium/issues/detail?id=669492) media device label, so you may need to make some minor changes to your application in order for Chromium WebView to work correctly.
+
+### Pre-requisites:
+- Android Studio 4.2.2+ installed on your machine
+
+### Deploy a Chime SDK for Javascript Meeting Demo
+If you'd like to try joining a WebRTC meeting demo from within a Chromium WebView in Android, you first need a meeting demo running in a browser so that when you load the WKWebView it can navigate to this meeting demo URL. Follow the instructions for the [Amazon Chime JS SDK Serverless Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless) in order to deploy a meeting demo.
+
+After you've deployed a meeting demo URL, take note of the meeting demo URL that was outputted to your terminal or in the Outputs tab of your cloudformation stack as part of the last step of deploying the [Amazon Chime SDK for Javascript Serverless Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless). Take the meeting demo URL, and replace the variable `url` in `./app/java/AppConfig.kt` with the value of the meeting demo URL.
+
+For example:
+```
+class AppConfig {
+    static String url = "https://xxxx.execute-api.us-east-1.amazonaws.com/Prod/"
+}
+```
+
+You can now build and run the Android application. There are issues with Android Studio's emulator that may cause issues for WebRTC, for best results deploy on a physical device.

--- a/apps/Android-WebView-sample/app/build.gradle
+++ b/apps/Android-WebView-sample/app/build.gradle
@@ -1,0 +1,65 @@
+/*
+ * build.gradle
+ * Android WebView Sample Demo
+ *
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ */
+
+plugins {
+    id 'com.android.application'
+}
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion 30
+    buildToolsVersion "30.0.2"
+
+    defaultConfig {
+        applicationId defaultApplicationId
+        minSdkVersion 29
+        targetSdkVersion 30
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    buildFeatures {
+        viewBinding true
+    }
+}
+
+dependencies {
+
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.navigation:navigation-fragment:2.3.5'
+    implementation 'androidx.navigation:navigation-ui:2.3.5'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation "androidx.core:core-ktx:+"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    // Optional -- Robolectric environment
+    testImplementation('androidx.test:core:1.4.0')
+    // Optional -- Mockito framework
+    testImplementation("org.mockito:mockito-core:1.10.19")
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.3.0')
+    androidTestImplementation('androidx.test.espresso:espresso-web:3.3.0')
+    androidTestImplementation 'androidx.test:rules:1.4.0'
+}
+repositories {
+    mavenCentral()
+}

--- a/apps/Android-WebView-sample/app/src/androidTest/java/com/amazonaws/android_webview_sample/AndroidWebView_UITest.kt
+++ b/apps/Android-WebView-sample/app/src/androidTest/java/com/amazonaws/android_webview_sample/AndroidWebView_UITest.kt
@@ -1,0 +1,116 @@
+/*
+ * AndroidWebView_UITest.kt
+ * Android WebView Sample Demo
+ *
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ */
+
+package com.amazonaws.android_webview_sample
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.web.sugar.Web
+import androidx.test.espresso.web.webdriver.DriverAtoms
+import androidx.test.espresso.web.webdriver.Locator
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import androidx.test.rule.GrantPermissionRule
+import androidx.test.runner.AndroidJUnit4
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class AndroidWebView_UITest {
+    var webLoadTime = 10000L
+    @Rule
+    @JvmField
+    // Run MainActivity
+    var mActivityTestRule = ActivityTestRule(MainActivity::class.java)
+
+    @Rule
+    @JvmField
+    // Grant protected permissions
+    var mGrantPermissionRule =
+            GrantPermissionRule.grant(
+                    "android.permission.CAMERA",
+                    "android.permission.RECORD_AUDIO")
+
+    @Test
+    fun mainActivityTest() {
+        // Press button to open
+        val materialButton = onView(withId(R.id.button_first))
+        materialButton.perform(click())
+
+        // Wait for page to load
+        Thread.sleep(webLoadTime)
+
+        // Enter a random meeting
+        Web.onWebView().withElement(DriverAtoms.findElement(Locator.ID, "inputMeeting")).perform(
+            DriverAtoms.webKeys(
+                UUID.randomUUID().toString()))
+        Web.onWebView().withElement(DriverAtoms.findElement(Locator.ID, "inputName")).perform(
+            DriverAtoms.webKeys(
+                UUID.randomUUID().toString()))
+        Web.onWebView().withElement(
+            DriverAtoms.findElement(
+                Locator.ID,
+                "authenticate"
+            )
+        ).perform(DriverAtoms.webClick())
+
+        // Wait for the device page
+        Thread.sleep(webLoadTime)
+
+        // Join the meeting
+        Web.onWebView().withElement(
+            DriverAtoms.findElement(
+                Locator.ID,
+                "joinButton"
+            )
+        ).perform(DriverAtoms.webClick())
+
+        // Wait to join the meeting
+        Thread.sleep(webLoadTime)
+
+        // Check for the microphone and camera button
+        Web.onWebView().withElement(
+            DriverAtoms.findElement(
+                Locator.ID,
+                "button-microphone"
+            )
+        )
+        Web.onWebView().withElement(
+            DriverAtoms.findElement(
+                Locator.ID,
+                "button-camera"
+            )
+        )
+    }
+    
+    private fun childAtPosition(
+            parentMatcher: Matcher<View>, position: Int): Matcher<View> {
+
+            return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description) {
+                description.appendText("Child at position $position in parent ")
+                parentMatcher.describeTo(description)
+            }
+
+            public override fun matchesSafely(view: View): Boolean {
+                val parent = view.parent
+                return parent is ViewGroup && parentMatcher.matches(parent)
+                        && view == parent.getChildAt(position)
+            }
+        }
+    }
+    }

--- a/apps/Android-WebView-sample/app/src/main/AndroidManifest.xml
+++ b/apps/Android-WebView-sample/app/src/main/AndroidManifest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ AndroidManifest.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.amazonaws.android_webview_sample">
+    <!-- Required for WebView to function correctly and have correct permissions -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AndroidWKWevViewsample"
+        android:fullBackupContent="@xml/backup_descriptor">
+        <activity
+            android:name="com.amazonaws.android_webview_sample.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/apps/Android-WebView-sample/app/src/main/java/com/amazonaws/android_webview_sample/AppConfig.kt
+++ b/apps/Android-WebView-sample/app/src/main/java/com/amazonaws/android_webview_sample/AppConfig.kt
@@ -1,0 +1,13 @@
+/*
+ * AppConfig.kt
+ * Android WebView Sample Demo
+ *
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ */
+package com.amazonaws.android_webview_sample
+
+object AppConfig {
+    // PUT YOUR MEETING URL HERE
+    var url = "PLACEHOLDER"
+}

--- a/apps/Android-WebView-sample/app/src/main/java/com/amazonaws/android_webview_sample/MainActivity.kt
+++ b/apps/Android-WebView-sample/app/src/main/java/com/amazonaws/android_webview_sample/MainActivity.kt
@@ -1,0 +1,32 @@
+/*
+ * MainActivity.kt
+ * Android WebView Sample Demo
+ *
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ */
+package com.amazonaws.android_webview_sample
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.Navigation
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.NavigationUI
+import com.amazonaws.android_webview_sample.databinding.ActivityMainBinding
+
+class MainActivity : AppCompatActivity() {
+    private val appBarConfiguration: AppBarConfiguration? = null
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val binding = ActivityMainBinding.inflate(
+            layoutInflater
+        )
+        setContentView(binding.root)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        val navController = Navigation.findNavController(this, R.id.nav_host_fragment_content_main)
+        return (NavigationUI.navigateUp(navController, appBarConfiguration!!)
+                || super.onSupportNavigateUp())
+    }
+}

--- a/apps/Android-WebView-sample/app/src/main/java/com/amazonaws/android_webview_sample/MainFragment.kt
+++ b/apps/Android-WebView-sample/app/src/main/java/com/amazonaws/android_webview_sample/MainFragment.kt
@@ -1,0 +1,40 @@
+/*
+ * MainFragment.kt
+ * Android WebView Sample Demo
+ *
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ */
+package com.amazonaws.android_webview_sample
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.NavHostFragment
+import com.amazonaws.android_webview_sample.databinding.FragmentMainBinding
+
+class MainFragment : Fragment() {
+    private var binding: FragmentMainBinding? = null
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentMainBinding.inflate(inflater, container, false)
+        return binding!!.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding!!.buttonFirst.setOnClickListener(View.OnClickListener {
+            NavHostFragment.findNavController(this@MainFragment)
+                .navigate(R.id.action_MainFragment_to_WebViewFragment)
+        })
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+}

--- a/apps/Android-WebView-sample/app/src/main/java/com/amazonaws/android_webview_sample/WebviewFragment.kt
+++ b/apps/Android-WebView-sample/app/src/main/java/com/amazonaws/android_webview_sample/WebviewFragment.kt
@@ -1,0 +1,92 @@
+/*
+ * WebviewFragment.kt
+ * Android WebView Sample Demo
+ *
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ */
+package com.amazonaws.android_webview_sample
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.PermissionRequest
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import com.amazonaws.android_webview_sample.databinding.FragmentWebviewBinding
+import java.util.Arrays
+
+
+class WebViewFragment : Fragment() {
+    private var binding: FragmentWebviewBinding? = null
+    private val WEBRTC_PERM = arrayOf(
+        Manifest.permission.RECORD_AUDIO,
+        Manifest.permission.CAMERA
+    )
+    var mWebView: WebView? = null
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentWebviewBinding.inflate(inflater, container, false)
+        return binding!!.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Grab the xml element
+        mWebView = binding!!.activityMainWebview
+        SetUpWebView()
+
+        // Load the url
+        mWebView!!.loadUrl(AppConfig.url)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
+    private fun HasWebRTCPermissions(): Boolean {
+        return Arrays.stream(WEBRTC_PERM).allMatch { it: String? ->
+            ContextCompat.checkSelfPermission(
+                requireContext(), it!!
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    private fun SetUpWebView() {
+        // Enable Javascript and disable media gesturing
+        val webSettings = mWebView?.settings
+        webSettings?.javaScriptEnabled = true
+        webSettings?.mediaPlaybackRequiresUserGesture = false
+        webSettings?.domStorageEnabled = true
+
+        //Create a new webview instance.
+        mWebView?.webViewClient = WebViewClient()
+
+        // Ask for application permissions
+        if (!HasWebRTCPermissions()) {
+            requestPermissions(WEBRTC_PERM, 1)
+        }
+        // Grant permissions to the browser
+        mWebView!!.webChromeClient = object : WebChromeClient() {
+            override fun getDefaultVideoPoster(): Bitmap? {
+                return Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888)
+            }
+            override fun onPermissionRequest(request: PermissionRequest) {
+                Log.d("UserAgent", mWebView!!.settings.userAgentString)
+                activity!!.runOnUiThread { request.grant(request.resources) }
+            }
+        }
+    }
+}

--- a/apps/Android-WebView-sample/app/src/main/res/layout/activity_main.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ activity_main.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/Theme.AndroidWKWevViewsample.AppBarOverlay"/>
+
+    <include
+        layout="@layout/content_main"
+        app:layout_anchor="@+id/activity_main_webview"
+        app:layout_anchorGravity="center" />
+
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/apps/Android-WebView-sample/app/src/main/res/layout/content_main.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/layout/content_main.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ content_main.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment_content_main"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/Android-WebView-sample/app/src/main/res/layout/fragment_main.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/layout/fragment_main.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ fragment_main.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/MainFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainFragment">
+    <Button
+        android:id="@+id/button_first"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:text="@string/next"
+        app:layout_anchorGravity="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/Android-WebView-sample/app/src/main/res/layout/fragment_webview.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/layout/fragment_webview.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ fragment_webview.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/WebViewFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".WebViewFragment">
+
+
+    <WebView
+        android:id="@+id/activity_main_webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/Android-WebView-sample/app/src/main/res/navigation/nav_graph.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ nav_graph.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    app:startDestination="@id/MainFragment">
+
+    <fragment
+        android:id="@+id/MainFragment"
+        android:name="com.amazonaws.android_webview_sample.MainFragment"
+        android:label="@string/main_fragment_label"
+        tools:layout="@layout/fragment_main">
+
+        <action
+            android:id="@+id/action_MainFragment_to_WebViewFragment"
+            app:destination="@id/WebViewFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/WebViewFragment"
+        android:name="com.amazonaws.android_webview_sample.WebViewFragment"
+        android:label="@string/webview_fragment_label"
+        tools:layout="@layout/fragment_webview">
+    </fragment>
+</navigation>

--- a/apps/Android-WebView-sample/app/src/main/res/values/colors.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/values/colors.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ colors.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<resources>
+    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_700">#FF018786</color>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/apps/Android-WebView-sample/app/src/main/res/values/strings.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/values/strings.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ strings.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<resources>
+    <string name="app_name">Android WebView Sample</string>
+    <!-- Strings used for fragments for navigation -->
+    <string name="main_fragment_label">Main Fragment</string>
+    <string name="webview_fragment_label">Webview Fragment</string>
+    <string name="next">Go to Webview</string>
+</resources>

--- a/apps/Android-WebView-sample/app/src/main/res/values/themes.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/values/themes.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ themes.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Base application theme. -->
+    <style name="Theme.AndroidWKWevViewsample" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <!-- Customize your theme here. -->
+    </style>
+
+    <style name="Theme.AndroidWKWevViewsample.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+</resources>

--- a/apps/Android-WebView-sample/app/src/main/res/xml/backup_descriptor.xml
+++ b/apps/Android-WebView-sample/app/src/main/res/xml/backup_descriptor.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ backup_descriptor.xml
+  ~ Android WebView Sample Demo
+  ~
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: MIT-0
+  -->
+
+<full-backup-content>
+    <!-- Exclude specific shared preferences that contain GCM registration Id -->
+</full-backup-content>

--- a/apps/Android-WebView-sample/build.gradle
+++ b/apps/Android-WebView-sample/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * build.gradle
+ * Android WebView Sample Demo
+ *
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ */
+
+ext {
+    defaultApplicationId = 'com.amazonaws.android_wkwevview_sample'
+}
+
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    ext.kotlin_version = '1.5.30-M1'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral() // Warning: this repository is going to shut down soon
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/apps/Android-WebView-sample/gradle.properties
+++ b/apps/Android-WebView-sample/gradle.properties
@@ -1,0 +1,25 @@
+#
+# gradle.properties
+# Android WebView Sample Demo
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app"s APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true

--- a/apps/Android-WebView-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/Android-WebView-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,14 @@
+#
+# gradle-wrapper.properties
+# Android WebView Sample Demo
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+
+#Thu Jul 15 14:40:02 PDT 2021
+distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionPath=wrapper/dists
+zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/apps/Android-WebView-sample/gradlew
+++ b/apps/Android-WebView-sample/gradlew
@@ -1,0 +1,182 @@
+#!/usr/bin/env sh
+
+#
+# //
+# //  Sample Solution
+# //  Chromium WebView Demo
+# //
+# //  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# //  SPDX-License-Identifier: MIT-0
+# //
+#
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "$*"
+}
+
+die () {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
+}
+APP_ARGS=$(save "$@")
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
+
+exec "$JAVACMD" "$@"

--- a/apps/Android-WebView-sample/gradlew.bat
+++ b/apps/Android-WebView-sample/gradlew.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/apps/Android-WebView-sample/settings.gradle
+++ b/apps/Android-WebView-sample/settings.gradle
@@ -1,0 +1,10 @@
+/*
+ * settings.gradle
+ * Android WebView Sample Demo
+ *
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ */
+
+rootProject.name = "Android-WKWevView-sample"
+include ':app'


### PR DESCRIPTION
**Issue #:**
Implement a demo showcasing the Chime SDK inside of Android WebView

**Description of changes:**
Added the Android WebView sample demo that showcases how to run a WebRTC meeting demo inside of Android WebView

**Testing**
1. How did you test these changes?
- Clone the AndroidWebView branch from https://github.com/aws/amazon-chime-sdk-js
- Build the sdk
- Build the browser demo
- Deploy the serverless demo and copy the given url for later
- Launch the newly added Android-Webview-sample folder in Android Studio 4.2.2
- In the AppConfig.kt file replace PLACEHOLDER with the url from the serverless demo
- Connect a physical android device that is in developer mode
- Launch the app on the physical device
- On the android device press the 'Go to WebView' button
- Fill in the fields on the page that appears
- Click continue
- Click continue on the next page
- Open the serverless url on another device and browser, then perform the last 3 steps
- Test for audio input on the android device
- Test for audio output on the android device
- Test for video input on the android device

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Yes, the serverless demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.