### PR TITLE
Incorporate voice focus feature in meeting demo

### DIFF
--- a/apps/meeting/src/app.tsx
+++ b/apps/meeting/src/app.tsx
@@ -9,7 +9,8 @@ import {
   MeetingProvider,
   NotificationProvider,
   darkTheme,
-  GlobalStyles
+  GlobalStyles,
+  VoiceFocusProvider,
 } from 'amazon-chime-sdk-component-library-react';
 
 import { AppStateProvider, useAppState } from './providers/AppStateProvider';
@@ -28,23 +29,25 @@ const App: FC = () => (
         <NotificationProvider>
           <Notifications />
           <ErrorProvider>
-            <MeetingProvider {...meetingConfig}>
-              <NavigationProvider>
-                <Switch>
-                  <Route exact path={routes.HOME} component={Home} />
-                  <Route path={routes.DEVICE}>
-                    <NoMeetingRedirect>
-                      <DeviceSetup />
-                    </NoMeetingRedirect>
-                  </Route>
-                  <Route path={routes.MEETING}>
-                    <NoMeetingRedirect>
-                      <MeetingModeSelector />
-                    </NoMeetingRedirect>
-                  </Route>
-                </Switch>
-              </NavigationProvider>
-            </MeetingProvider>
+            <VoiceFocusProvider>
+              <MeetingProvider {...meetingConfig}>
+                <NavigationProvider>
+                  <Switch>
+                    <Route exact path={routes.HOME} component={Home} />
+                    <Route path={routes.DEVICE}>
+                      <NoMeetingRedirect>
+                        <DeviceSetup />
+                      </NoMeetingRedirect>
+                    </Route>
+                    <Route path={routes.MEETING}>
+                      <NoMeetingRedirect>
+                        <MeetingModeSelector />
+                      </NoMeetingRedirect>
+                    </Route>
+                  </Switch>
+                </NavigationProvider>
+              </MeetingProvider>
+            </VoiceFocusProvider>
           </ErrorProvider>
         </NotificationProvider>
       </Theme>

--- a/apps/meeting/src/containers/MeetingControls/index.tsx
+++ b/apps/meeting/src/containers/MeetingControls/index.tsx
@@ -4,13 +4,13 @@
 import React from 'react';
 import {
   ControlBar,
-  AudioInputControl,
+  AudioInputVFControl,
   VideoInputControl,
   ContentShareControl,
   AudioOutputControl,
   ControlBarButton,
   useUserActivityState,
-  Dots
+  Dots,
 } from 'amazon-chime-sdk-component-library-react';
 
 import EndMeetingControl from '../EndMeetingControl';
@@ -42,7 +42,7 @@ const MeetingControls = () => {
           onClick={handleToggle}
           label="Menu"
         />
-        <AudioInputControl />
+        <AudioInputVFControl />
         <VideoInputControl />
         <ContentShareControl />
         <AudioOutputControl />

--- a/apps/meeting/src/meetingConfig.ts
+++ b/apps/meeting/src/meetingConfig.ts
@@ -7,7 +7,6 @@ const urlParams = new URLSearchParams(window.location.search);
 const queryLogLevel = urlParams.get('logLevel') || 'warn';
 const logLevel = SDK_LOG_LEVELS[queryLogLevel] || SDK_LOG_LEVELS.warn;
 
-
 const BASE_URL: string = [
   location.protocol,
   '//',
@@ -20,12 +19,15 @@ const postLogConfig = {
   batchSize: 85,
   intervalMs: 2000,
   url: `${BASE_URL}logs`,
-  logLevel: SDK_LOG_LEVELS.info
+  logLevel: SDK_LOG_LEVELS.info,
 };
+
+const enableWebAudio = true;
 
 const config = {
   logLevel,
-  postLogConfig
+  postLogConfig,
+  enableWebAudio,
 };
 
 export default config;


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:**
Add `<VoiceFocusProvider>` in the meeting demo and replace `<AudioInputControl>` with `<AudioInputVFControl>` to show the voice focus feature.

**Testing**

1. How did you test these changes? Run the meeting demo, click the voice focus option in the dropdown list of microphone icon. Then a normal input audio device is wrapped with the voice focus transformer
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?Yes, meeting demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.