### PR TITLE
fixes aws-samples/amazon-chime-sdk#45: Show attachment when recieving message via WebSocket

### DIFF
--- a/apps/chat/src/providers/ChatMessagesProvider/index.jsx
+++ b/apps/chat/src/providers/ChatMessagesProvider/index.jsx
@@ -106,9 +106,11 @@ const MessagingProvider = ({ children }) => {
           if (metadata.isMeetingInfo && record.Sender.Arn !== createMemberArn(member.userId)) {
             const meetingInfo = JSON.parse(record.Content);
             setMeetingInfo(meetingInfo);
+            break;
           };
         }
-        else if (activeChannelRef.current.ChannelArn === record?.ChannelArn) {
+
+        if (activeChannelRef.current.ChannelArn === record?.ChannelArn) {
           processChannelMessage(record);
         } else {
           const findMatch = unreadChannelsListRef.current.find(


### PR DESCRIPTION
**Issue #45 :**


**Description of changes:**

**Testing**

1. How did you test these changes?

Launch demo, send message with attachement, confirm shows in chat.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

The chat demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.