### PR TITLE
Split webpack to dev and prod to reduce the bundle size for serverless demo

### DIFF
--- a/apps/meeting/package.json
+++ b/apps/meeting/package.json
@@ -8,8 +8,8 @@
     "@types/webpack-env": "^1.15.1",
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
-    "amazon-chime-sdk-component-library-react": "^2.9.0",
-    "amazon-chime-sdk-js": "^2.16.1",
+    "amazon-chime-sdk-component-library-react": "^2.9.1",
+    "amazon-chime-sdk-js": "^2.17.0",
     "aws-sdk": "^2.731.0",
     "fs-extra": "^10.0.0",
     "react": "^17.0.1",
@@ -22,7 +22,7 @@
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx --fix",
     "build": "webpack --config ./webpack.config.js",
-    "start:client": "npm run build && webpack serve",
+    "start:client": "webpack --config ./webpack.config.dev.js && webpack serve",
     "start:backend": "node server.js",
     "start": "concurrently \"npm run start:client\" \"npm run start:backend\""
   },

--- a/apps/meeting/webpack.config.dev.js
+++ b/apps/meeting/webpack.config.dev.js
@@ -1,0 +1,3 @@
+const config = require('./webpack.config.js');
+
+module.exports = Object.assign(config, { mode: 'development', devtool: 'inline-source-map' });

--- a/apps/meeting/webpack.config.js
+++ b/apps/meeting/webpack.config.js
@@ -8,9 +8,9 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const app = 'meeting';
 
 module.exports = {
-  mode: 'development',
+  mode: 'production',
   entry: ['./src/index.tsx'],
-  devtool: 'inline-source-map',
+  devtool: false,
   module: {
     rules: [
       {


### PR DESCRIPTION
**Description of changes:**
Running in dev with inline-source-map makes the bundle size bigger than the Lambda limit so serverless demo would not be able to fetch the page.
Create a new dev webpack config to run with npm run start for debugging. npm run build will use the default - production mode to reduce the bundle size.

**Testing**

1. How did you test these changes? 
- Test both `npm run start` and `npm run build` and verify the bundle size.
- Do serverless deployment and verify that it loads
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? Yes, meeting demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.