### PR TITLE
Update node script to enable webpack dev mode

### DIFF
--- a/apps/meeting/package.json
+++ b/apps/meeting/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx --fix",
     "build": "webpack --config ./webpack.config.js",
-    "start:client": "webpack --config ./webpack.config.dev.js && webpack serve",
+    "start:client": "webpack serve --config ./webpack.config.dev.js",
     "start:backend": "node server.js",
     "start": "concurrently \"npm run start:client\" \"npm run start:backend\""
   },


### PR DESCRIPTION
**Issue #:**
Running `webpack serve` does not use `webpack.config.dev.js`.
It only works when webpack is building the project. 

**Description of changes:**
Update the node script to use the `webpack.config.dev.js` when running locally.

**Testing**

1. How did you test these changes?
Yes, in both dev and prod mode, check the demo app and webpack work well .

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
React meeting demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.