### PR TITLE
Replace gettingStarted guide link with API overview link in ReadMe

### DIFF
--- a/utils/singlejs/README.md
+++ b/utils/singlejs/README.md
@@ -18,7 +18,7 @@ It will generate `amazon-chime-sdk.min.js` and `amazon-chime-sdk.min.js.map` in 
 ### Using ChimeSDK
 
 In a browser environment, `window.ChimeSDK` will be available. You can access Chime SDK components by component name ([See the full list here](https://github.com/aws/amazon-chime-sdk-js/blob/master/src/index.ts)).
-For example, you can rewrite [the Meeting Application example](https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html#meeting-application) using `window.ChimeSDK`.
+For example, you can [create a meeting session](https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html#1-create-a-session) and [configure the meeting session](https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html#2-configure-the-session) using `window.ChimeSDK`.
 
 ```js
 const logger = new ChimeSDK.ConsoleLogger('ChimeMeetingLogs', ChimeSDK.LogLevel.INFO);


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
We will delete the getting started guide in Chime JS SDK. Replace gettingStarted guide link with API overview link in ReadMe

**Testing**

1. How did you test these changes? N/A
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.