### PR TITLE
Fix Auto Enable web audio in Meeting Demo

### DIFF
--- a/apps/meeting/src/app.tsx
+++ b/apps/meeting/src/app.tsx
@@ -1,9 +1,9 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import React, { FC } from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import { ThemeProvider } from 'styled-components';
+import React, { FC } from "react";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { ThemeProvider } from "styled-components";
 import {
   lightTheme,
   MeetingProvider,
@@ -11,17 +11,17 @@ import {
   darkTheme,
   GlobalStyles,
   VoiceFocusProvider,
-} from 'amazon-chime-sdk-component-library-react';
+} from "amazon-chime-sdk-component-library-react";
 
-import { AppStateProvider, useAppState } from './providers/AppStateProvider';
-import ErrorProvider from './providers/ErrorProvider';
-import routes from './constants/routes';
-import { NavigationProvider } from './providers/NavigationProvider';
-import { Meeting, Home, DeviceSetup } from './views';
-import Notifications from './containers/Notifications';
-import NoMeetingRedirect from './containers/NoMeetingRedirect';
-import MeetingEventObserver from './containers/MeetingEventObserver';
-import meetingConfig from './meetingConfig';
+import { AppStateProvider, useAppState } from "./providers/AppStateProvider";
+import ErrorProvider from "./providers/ErrorProvider";
+import routes from "./constants/routes";
+import { NavigationProvider } from "./providers/NavigationProvider";
+import { Meeting, Home, DeviceSetup } from "./views";
+import Notifications from "./containers/Notifications";
+import NoMeetingRedirect from "./containers/NoMeetingRedirect";
+import MeetingEventObserver from "./containers/MeetingEventObserver";
+import meetingConfig from "./meetingConfig";
 
 const App: FC = () => (
   <Router>
@@ -31,24 +31,7 @@ const App: FC = () => (
           <Notifications />
           <ErrorProvider>
             <VoiceFocusProvider>
-              <MeetingProvider {...meetingConfig}>
-                <NavigationProvider>
-                  <Switch>
-                    <Route exact path={routes.HOME} component={Home} />
-                    <Route path={routes.DEVICE}>
-                      <NoMeetingRedirect>
-                        <DeviceSetup />
-                      </NoMeetingRedirect>
-                    </Route>
-                    <Route path={routes.MEETING}>
-                      <NoMeetingRedirect>
-                        <MeetingModeSelector />
-                      </NoMeetingRedirect>
-                    </Route>
-                  </Switch>
-                </NavigationProvider>
-                <MeetingEventObserver />
-              </MeetingProvider>
+              <MeetingWrapper />
             </VoiceFocusProvider>
           </ErrorProvider>
         </NotificationProvider>
@@ -57,11 +40,34 @@ const App: FC = () => (
   </Router>
 );
 
+const MeetingWrapper: React.FC = ({ children }) => {
+  return (
+    <MeetingProvider {...meetingConfig}>
+      <NavigationProvider>
+        <Switch>
+          <Route exact path={routes.HOME} component={Home} />
+          <Route path={routes.DEVICE}>
+            <NoMeetingRedirect>
+              <DeviceSetup />
+            </NoMeetingRedirect>
+          </Route>
+          <Route path={routes.MEETING}>
+            <NoMeetingRedirect>
+              <MeetingModeSelector />
+            </NoMeetingRedirect>
+          </Route>
+        </Switch>
+      </NavigationProvider>
+      <MeetingEventObserver />
+    </MeetingProvider>
+  );
+};
+
 const Theme: React.FC = ({ children }) => {
   const { theme } = useAppState();
 
   return (
-    <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme}>
+    <ThemeProvider theme={theme === "light" ? lightTheme : darkTheme}>
       <GlobalStyles />
       {children}
     </ThemeProvider>
@@ -71,9 +77,7 @@ const Theme: React.FC = ({ children }) => {
 const MeetingModeSelector: React.FC = () => {
   const { meetingMode } = useAppState();
 
-  return (
-    <Meeting mode={meetingMode} />
-  );
+  return <Meeting mode={meetingMode} />;
 };
 
 export default App;

--- a/apps/meeting/src/app.tsx
+++ b/apps/meeting/src/app.tsx
@@ -41,8 +41,15 @@ const App: FC = () => (
 );
 
 const MeetingWrapper: React.FC = ({ children }) => {
+
+  const  { isWebAudioEnabled } =  useAppState();
+
+  const meetingConfigValue = {...meetingConfig,
+    enableWebAudio: isWebAudioEnabled
+  };
+
   return (
-    <MeetingProvider {...meetingConfig}>
+    <MeetingProvider {...meetingConfigValue}>
       <NavigationProvider>
         <Switch>
           <Route exact path={routes.HOME} component={Home} />

--- a/apps/meeting/src/containers/MeetingControls/index.tsx
+++ b/apps/meeting/src/containers/MeetingControls/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {
   ControlBar,
   AudioInputVFControl,
+  AudioInputControl,
   VideoInputControl,
   ContentShareControl,
   AudioOutputControl,
@@ -16,16 +17,17 @@ import {
 import EndMeetingControl from '../EndMeetingControl';
 import { useNavigation } from '../../providers/NavigationProvider';
 import { StyledControls } from './Styled';
+import { useAppState } from '../../providers/AppStateProvider';
 
-const MeetingControls = () => {
+const MeetingControls = (): JSX.Element => {
   const { toggleNavbar, closeRoster, showRoster } = useNavigation();
   const { isUserActive } = useUserActivityState();
+  const { isWebAudioEnabled } = useAppState();
 
-  const handleToggle = () => {
+  const handleToggle = (): void => {
     if (showRoster) {
       closeRoster();
     }
-
     toggleNavbar();
   };
 
@@ -42,7 +44,7 @@ const MeetingControls = () => {
           onClick={handleToggle}
           label="Menu"
         />
-        <AudioInputVFControl />
+        { isWebAudioEnabled ? <AudioInputVFControl /> :  <AudioInputControl /> }
         <VideoInputControl />
         <ContentShareControl />
         <AudioOutputControl />

--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -32,7 +32,9 @@ const MeetingForm: React.FC = () => {
   const {
     setAppMeetingInfo,
     region: appRegion,
-    meetingId: appMeetingId
+    meetingId: appMeetingId,
+    isWebAudioEnabled,
+    toggleWebAudio
   } = useAppState();
   const [meetingId, setMeetingId] = useState(appMeetingId);
   const [meetingErr, setMeetingErr] = useState(false);
@@ -142,9 +144,16 @@ const MeetingForm: React.FC = () => {
         label="Join w/o Audio and Video"
         value=""
         checked={isSpectatorModeSelected}
-        onChange={() => (
+        onChange={(): void => (
           setIsSpectatorModeSelected(!isSpectatorModeSelected)
         )}
+      />
+      <FormField
+        field={Checkbox}
+        label="Enable Web Audio"
+        value=""
+        checked={isWebAudioEnabled}
+        onChange={toggleWebAudio}
       />
       <Flex
         container

--- a/apps/meeting/src/meetingConfig.ts
+++ b/apps/meeting/src/meetingConfig.ts
@@ -22,7 +22,7 @@ const postLogConfig = {
   logLevel: SDK_LOG_LEVELS.info,
 };
 
-const enableWebAudio = true;
+const enableWebAudio = false;
 
 const config = {
   logLevel,

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -13,8 +13,10 @@ interface AppStateValue {
   localUserName: string;
   theme: string;
   region: string;
+  isWebAudioEnabled: boolean;
   meetingMode: MeetingMode;
   toggleTheme: () => void;
+  toggleWebAudio: () => void;
   setAppMeetingInfo: (meetingId: string, name: string, region: string) => void;
   setMeetingMode: (meetingMode: MeetingMode) => void;
 }
@@ -33,11 +35,13 @@ export function useAppState(): AppStateValue {
 
 const query = new URLSearchParams(location.search);
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function AppStateProvider({ children }: Props) {
   const [meetingId, setMeeting] = useState(query.get('meetingId') || '');
   const [region, setRegion] = useState(query.get('region') || '');
   const [meetingMode, setMeetingMode] = useState(MeetingMode.Attendee);
   const [localUserName, setLocalName] = useState('');
+  const [isWebAudioEnabled, setIsWebAudioEnabled] = useState(false);
   const [theme, setTheme] = useState(() => {
     const storedTheme = localStorage.getItem('theme');
     return storedTheme || 'light';
@@ -53,11 +57,15 @@ export function AppStateProvider({ children }: Props) {
     }
   };
 
+  const toggleWebAudio = (): void  => {
+    setIsWebAudioEnabled(!isWebAudioEnabled);
+  }
+
   const setAppMeetingInfo = (
     meetingId: string,
     name: string,
     region: string
-  ) => {
+  ): void => {
     setRegion(region);
     setMeeting(meetingId);
     setLocalName(name);
@@ -67,9 +75,11 @@ export function AppStateProvider({ children }: Props) {
     meetingId,
     localUserName,
     theme,
+    isWebAudioEnabled,
     region,
     meetingMode,
     toggleTheme,
+    toggleWebAudio,
     setAppMeetingInfo,
     setMeetingMode,
   };


### PR DESCRIPTION
**Issue #:**
Currently Web audo is enable by default which is causing audio fade issue in Safari.

**Description of changes:**
- Disable webAudio by default in meeting Config and provide a way to enable in meeting form.
- In Meeting Controls show AudioinputVoiceFocusControl only if web audio is enabled.

**Testing**

1. How did you test these changes?
- Open Meeting Demo
- Do not enable web audio check box.
- AudioinputVoiceControl should not be shown.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Meeting Demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.