### PR TITLE
Add BackgroundBlurDeviceProvider and VideoInputBackgroundBlurControl to meeting demo

### DIFF
--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^2.19.2",
         "@typescript-eslint/parser": "^2.19.2",
         "amazon-chime-sdk-component-library-react": "^2.11.1",
-        "amazon-chime-sdk-js": "^2.17.0",
+        "amazon-chime-sdk-js": "^2.20.0",
         "aws-sdk": "^2.731.0",
         "fs-extra": "^10.0.0",
         "react": "^17.0.1",
@@ -2437,9 +2437,9 @@
       "dev": true
     },
     "node_modules/detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
+      "integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg=="
     },
     "node_modules/detect-node": {
       "version": "2.0.5",
@@ -12777,9 +12777,9 @@
       "dev": true
     },
     "detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
+      "integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg=="
     },
     "detect-node": {
       "version": "2.0.5",

--- a/apps/meeting/package.json
+++ b/apps/meeting/package.json
@@ -9,7 +9,7 @@
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
     "amazon-chime-sdk-component-library-react": "^2.11.1",
-    "amazon-chime-sdk-js": "^2.17.0",
+    "amazon-chime-sdk-js": "^2.20.0",
     "aws-sdk": "^2.731.0",
     "fs-extra": "^10.0.0",
     "react": "^17.0.1",

--- a/apps/meeting/src/containers/MeetingControls/index.tsx
+++ b/apps/meeting/src/containers/MeetingControls/index.tsx
@@ -6,12 +6,13 @@ import {
   ControlBar,
   AudioInputVFControl,
   AudioInputControl,
-  VideoInputControl,
+  VideoInputBackgroundBlurControl,
   ContentShareControl,
   AudioOutputControl,
   ControlBarButton,
   useUserActivityState,
   Dots,
+  VideoInputControl,
 } from 'amazon-chime-sdk-component-library-react';
 
 import EndMeetingControl from '../EndMeetingControl';
@@ -22,7 +23,7 @@ import { useAppState } from '../../providers/AppStateProvider';
 const MeetingControls: React.FC = () => {
   const { toggleNavbar, closeRoster, showRoster } = useNavigation();
   const { isUserActive } = useUserActivityState();
-  const { isWebAudioEnabled } = useAppState();
+  const { isWebAudioEnabled, isBackgroundBlurEnabled } = useAppState();
 
   const handleToggle = (): void => {
     if (showRoster) {
@@ -45,7 +46,7 @@ const MeetingControls: React.FC = () => {
           label="Menu"
         />
         { isWebAudioEnabled ? <AudioInputVFControl /> :  <AudioInputControl /> }
-        <VideoInputControl />
+        { isBackgroundBlurEnabled ? <VideoInputBackgroundBlurControl/> : <VideoInputControl/> }
         <ContentShareControl />
         <AudioOutputControl />
         <EndMeetingControl />

--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -34,7 +34,10 @@ const MeetingForm: React.FC = () => {
     region: appRegion,
     meetingId: appMeetingId,
     isWebAudioEnabled,
-    toggleWebAudio
+    isBackgroundBlurEnabled,
+    toggleBackgroundBlur,
+    toggleWebAudio,
+    setMeetingMode
   } = useAppState();
   const [meetingId, setMeetingId] = useState(appMeetingId);
   const [meetingErr, setMeetingErr] = useState(false);
@@ -45,7 +48,6 @@ const MeetingForm: React.FC = () => {
   const [isSpectatorModeSelected, setIsSpectatorModeSelected] = useState(false);
   const { errorMessage, updateErrorMessage } = useContext(getErrorContext());
   const history = useHistory();
-  const { setMeetingMode } = useAppState();
 
   const handleJoinMeeting = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -158,6 +160,13 @@ const MeetingForm: React.FC = () => {
         checked={isWebAudioEnabled}
         onChange={toggleWebAudio}
         infoText="Enable Web Audio to use Voice Focus"
+      />
+      <FormField
+        field={Checkbox}
+        label="Enable Background Blur"
+        value=""
+        checked={isBackgroundBlurEnabled}
+        onChange={toggleBackgroundBlur}
       />
       <Flex
         container

--- a/apps/meeting/src/containers/MeetingProviderWrapper/index.tsx
+++ b/apps/meeting/src/containers/MeetingProviderWrapper/index.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import {
+  BackgroundBlurProvider,
   MeetingProvider,
   VoiceFocusProvider,
 } from 'amazon-chime-sdk-component-library-react';
@@ -17,7 +18,7 @@ import meetingConfig from '../../meetingConfig';
 import { useAppState } from '../../providers/AppStateProvider';
 
 const MeetingProviderWrapper: React.FC = () => {
-  const { isWebAudioEnabled } = useAppState();
+  const { isWebAudioEnabled, isBackgroundBlurEnabled } = useAppState();
 
   const meetingConfigValue = {
     ...meetingConfig,
@@ -47,17 +48,36 @@ const MeetingProviderWrapper: React.FC = () => {
     );
   };
 
-  const getMeetingProviderWrapperWithVF = () => {
+  const getMeetingProviderWrapperWithVF = (children: React.ReactNode) => {
     return (
       <VoiceFocusProvider>
-        {getMeetingProviderWrapper()}
+        {children}
       </VoiceFocusProvider>
     );
   };
 
+  const getMeetingProviderWrapperWithBGBlur = (children: React.ReactNode) => {
+    return (
+      <BackgroundBlurProvider>
+        {children}
+      </BackgroundBlurProvider>
+    );
+  };
+
+  const getMeetingProviderWithFeatures = () : React.ReactNode => {
+    let children = getMeetingProviderWrapper();
+    if (isWebAudioEnabled) {
+      children = getMeetingProviderWrapperWithVF(children);
+    }
+    if (isBackgroundBlurEnabled) {
+      children = getMeetingProviderWrapperWithBGBlur(children);
+    }
+    return children;
+  };
+
   return (
     <>
-      {isWebAudioEnabled ? getMeetingProviderWrapperWithVF() : getMeetingProviderWrapper()}
+      {getMeetingProviderWithFeatures()}
     </>
   );
 };

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -14,10 +14,12 @@ interface AppStateValue {
   theme: string;
   region: string;
   isWebAudioEnabled: boolean;
+  isBackgroundBlurEnabled: boolean;
   meetingMode: MeetingMode;
   layout: Layout;
   toggleTheme: () => void;
   toggleWebAudio: () => void;
+  toggleBackgroundBlur: () => void;
   setAppMeetingInfo: (meetingId: string, name: string, region: string) => void;
   setMeetingMode: (meetingMode: MeetingMode) => void;
   setLayout: (layout: Layout) => void;
@@ -44,7 +46,8 @@ export function AppStateProvider({ children }: Props) {
   const [meetingMode, setMeetingMode] = useState(MeetingMode.Attendee);
   const [layout, setLayout] = useState(Layout.Gallery);
   const [localUserName, setLocalName] = useState('');
-  const [isWebAudioEnabled, setIsWebAudioEnabled] = useState(false);
+  const [isWebAudioEnabled, setIsWebAudioEnabled] = useState(true);
+  const [isBackgroundBlurEnabled, setIsBackgroundBlurEnabled] = useState(true);
   const [theme, setTheme] = useState(() => {
     const storedTheme = localStorage.getItem('theme');
     return storedTheme || 'light';
@@ -64,6 +67,10 @@ export function AppStateProvider({ children }: Props) {
     setIsWebAudioEnabled(current => !current);
   }
 
+  const toggleBackgroundBlur = (): void  => {
+    setIsBackgroundBlurEnabled(current => !current);
+  }
+
   const setAppMeetingInfo = (
     meetingId: string,
     name: string,
@@ -79,11 +86,13 @@ export function AppStateProvider({ children }: Props) {
     localUserName,
     theme,
     isWebAudioEnabled,
+    isBackgroundBlurEnabled,
     region,
     meetingMode,
     layout,
     toggleTheme,
     toggleWebAudio,
+    toggleBackgroundBlur,
     setAppMeetingInfo,
     setMeetingMode,
     setLayout,

--- a/apps/meeting/webpack.config.js
+++ b/apps/meeting/webpack.config.js
@@ -60,12 +60,6 @@ module.exports = {
     proxy: {
       '/': {
         target: 'http://localhost:8080',
-        bypass: function(req, _res, _proxyOptions) {
-          if (req.headers.accept.indexOf('html') !== -1) {
-            console.log('Skipping proxy for browser request.');
-            return `/${app}.html`;
-          }
-        }
       }
     },
     static: {
@@ -75,11 +69,15 @@ module.exports = {
       index: `${app}.html`,
       writeToDisk: true,
     },
+    client: {
+      overlay: false,
+    },
     liveReload: true,
     hot: false,
     host: '0.0.0.0',
     port: 9000,
     https: true,
     historyApiFallback: true,
+    open: true,
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "amazon-chime-sdk",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
**Issue #:**
https://github.com/aws/amazon-chime-sdk-js/issues/1690

**Description of changes:**
Add the `BackgroundBlurDeviceProvider` to the main component tree and `VideoInputBackgroundBlurControl` to the `MeetingControls`.

This depends on the 2.11.0 version of the Amazon Chime React SDK Component Library and also the 2.20.0 version of the Amazon Chime SDK for Javascript. Both have not been released yet, so this PR will sit in PR until both are released. 

**Testing**

1. How did you test these changes?

```
1. npm run start
2. join a meeting
3. toggle video on and off
4. enable bg blur
5. toggle video on and off
6. switch between videos
```

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.