### PR TITLE
Add react component library declaration

### DIFF
--- a/apps/meeting/tsconfig.json
+++ b/apps/meeting/tsconfig.json
@@ -23,10 +23,15 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "suppressImplicitAnyIndexErrors": true,
+    "typeRoots": [
+      "node_modules/@types",
+      "typings"
+    ]
   },
   "include": ["src/**/*"],
   "exclude": [
     "node_modules",
-    "build"
+    "build",
+    "typings"
   ]
 }

--- a/apps/meeting/typings/amazon-chime-sdk-component-library-react.d.ts
+++ b/apps/meeting/typings/amazon-chime-sdk-component-library-react.d.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+declare module 'amazon-chime-sdk-component-library-react';


### PR DESCRIPTION
To solve TS7016: Could not find a declaration file for module amazon-chime-sdk-component-library-react error in GitHub actions.

**Issue #:**
- The react component library is failing webpack building while the deploy github action workflow runs.
- The error is:
```
TS7016: Could not find a declaration file for module 'amazon-chime-sdk-component-library-react'. '/home/runner/work/amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react/amazon-chime-sdk/apps/meeting/node_modules/amazon-chime-sdk-component-library-react/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/amazon-chime-sdk-component-library-react` if it exists or add a new declaration (.d.ts) file containing `declare module 'amazon-chime-sdk-component-library-react';`
```
- Failed GitHub action run: https://github.com/aws/amazon-chime-sdk-component-library-react/runs/3954637032

**Description of changes:**
- Adds declaration module and makes corresponding changes in `tsconfig` to test if this solves, if not, we will be excluding the `tst` folder from linting to figure out the root cause later and unblock the deploy workflow run successfully again.

**Testing**

1. How did you test these changes?
- Ran the demo locally as well as by deploying a copy with NPM 7 and Node 16 which is matching the GitHub actions.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
- Basic feature testing will implicitly test this as the demo will fail to compile if this change has issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.