### PR TITLE
Add VideoFilterSelection component to React meeting demo device selection page

### DIFF
--- a/apps/meeting/src/components/DeviceSelection/CameraDevices/index.tsx
+++ b/apps/meeting/src/components/DeviceSelection/CameraDevices/index.tsx
@@ -7,7 +7,8 @@ import {
   PreviewVideo,
   QualitySelection,
   CameraSelection,
-  Label
+  Label,
+  VideoFilterSelection
 } from 'amazon-chime-sdk-component-library-react';
 
 import { title, StyledInputGroup } from '../Styled';
@@ -23,6 +24,9 @@ const CameraDevices = () => {
       </StyledInputGroup>
       <StyledInputGroup>
         <QualitySelection />
+      </StyledInputGroup>
+      <StyledInputGroup>
+        <VideoFilterSelection />
       </StyledInputGroup>
       <Label style={{ display: 'block', marginBottom: '.5rem' }}>
         Video preview


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Add VideoFilterSelection component to React meeting demo device selection page.
The components used are added in this PR: https://github.com/aws/amazon-chime-sdk-component-library-react/pull/661

![image](https://user-images.githubusercontent.com/54328451/139965123-96965195-c657-4542-95d7-1bcee3020509.png)


**Testing**

1. How did you test these changes?
tested on the demo app.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
React Meeting demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.