### PR TITLE
Update meeting app to inclue CPU utilization options for background blur

### DIFF
--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -14,8 +14,8 @@
         "@types/webpack-env": "^1.15.1",
         "@typescript-eslint/eslint-plugin": "^2.19.2",
         "@typescript-eslint/parser": "^2.19.2",
-        "amazon-chime-sdk-component-library-react": "^2.11.1",
-        "amazon-chime-sdk-js": "^2.20.0",
+        "amazon-chime-sdk-component-library-react": "/Volumes/workplace/github/react/amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react-2.11.1.tgz",
+        "amazon-chime-sdk-js": "^2.21.1",
         "aws-sdk": "^2.731.0",
         "fs-extra": "^10.0.0",
         "react": "^17.0.1",
@@ -855,8 +855,9 @@
     },
     "node_modules/amazon-chime-sdk-component-library-react": {
       "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-component-library-react/-/amazon-chime-sdk-component-library-react-2.11.1.tgz",
-      "integrity": "sha512-Fa6QTZIM8/XGkGYNUka/S9YwBCcgtuu71eRR0h61+S1u3xOZa7ohOw0OJO/Vp6jIIlLUa76ES2uKPr9qbK+SvA==",
+      "resolved": "file:../../../amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react-2.11.1.tgz",
+      "integrity": "sha512-aSUhCQYapV2Qf8R+GfsXErUleOk2t8BXFxyHLpV7zk2Rs2R9GdjVZW42cbaMR3VY4dRDJ+kRmnuJtSKkKCJPZw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@popperjs/core": "^2.2.2",
         "fast-memoize": "^2.5.2",
@@ -886,16 +887,16 @@
       }
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.20.0.tgz",
-      "integrity": "sha512-DcfypnhZ5q7ppU0celTWRC9IyyDxAnPX5sImkzGFqM4cSahZV+IFvIbpqStQWi62+pd2SDQlbq6Ducp4/D7zwA==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.21.1.tgz",
+      "integrity": "sha512-Y8/qabhzIMMvicu/4RAYezFJzBAV0fs4yOD9fCmwdTmNIbq35/X6rpgI8AmpqRNhob1Xv7X/5+elKPYgxhiTfg==",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^1.0.1"
       },
       "engines": {
         "node": "^12 || ^14 || ^15 || ^16",
@@ -9826,9 +9827,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11502,9 +11503,8 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "amazon-chime-sdk-component-library-react": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-component-library-react/-/amazon-chime-sdk-component-library-react-2.11.1.tgz",
-      "integrity": "sha512-Fa6QTZIM8/XGkGYNUka/S9YwBCcgtuu71eRR0h61+S1u3xOZa7ohOw0OJO/Vp6jIIlLUa76ES2uKPr9qbK+SvA==",
+      "version": "file:/Volumes/workplace/github/react/amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react-2.11.1.tgz",
+      "integrity": "sha512-aSUhCQYapV2Qf8R+GfsXErUleOk2t8BXFxyHLpV7zk2Rs2R9GdjVZW42cbaMR3VY4dRDJ+kRmnuJtSKkKCJPZw==",
       "requires": {
         "@popperjs/core": "^2.2.2",
         "fast-memoize": "^2.5.2",
@@ -11522,16 +11522,16 @@
       }
     },
     "amazon-chime-sdk-js": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.20.0.tgz",
-      "integrity": "sha512-DcfypnhZ5q7ppU0celTWRC9IyyDxAnPX5sImkzGFqM4cSahZV+IFvIbpqStQWi62+pd2SDQlbq6Ducp4/D7zwA==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.21.1.tgz",
+      "integrity": "sha512-Y8/qabhzIMMvicu/4RAYezFJzBAV0fs4yOD9fCmwdTmNIbq35/X6rpgI8AmpqRNhob1Xv7X/5+elKPYgxhiTfg==",
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^1.0.1"
       }
     },
     "ansi-escapes": {
@@ -18743,9 +18743,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/apps/meeting/package.json
+++ b/apps/meeting/package.json
@@ -9,7 +9,7 @@
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
     "amazon-chime-sdk-component-library-react": "^2.11.1",
-    "amazon-chime-sdk-js": "^2.20.0",
+    "amazon-chime-sdk-js": "^2.21.1",
     "aws-sdk": "^2.731.0",
     "fs-extra": "^10.0.0",
     "react": "^17.0.1",

--- a/apps/meeting/src/constants/index.ts
+++ b/apps/meeting/src/constants/index.ts
@@ -52,3 +52,10 @@ export const SDK_LOG_LEVELS = {
   'error': LogLevel.ERROR,
   'off': LogLevel.OFF,
 }
+
+export const BlurValues = {
+  blurDisabled: "0",
+  blur10Percent: "10",
+  blur20Percent: "20",
+  blur40Percent: "40",
+}

--- a/apps/meeting/src/containers/MeetingControls/index.tsx
+++ b/apps/meeting/src/containers/MeetingControls/index.tsx
@@ -19,11 +19,13 @@ import EndMeetingControl from '../EndMeetingControl';
 import { useNavigation } from '../../providers/NavigationProvider';
 import { StyledControls } from './Styled';
 import { useAppState } from '../../providers/AppStateProvider';
+import { BlurValues } from '../../constants';
 
 const MeetingControls: React.FC = () => {
   const { toggleNavbar, closeRoster, showRoster } = useNavigation();
   const { isUserActive } = useUserActivityState();
-  const { isWebAudioEnabled, isBackgroundBlurEnabled } = useAppState();
+  const { isWebAudioEnabled, blurOption } = useAppState();
+  const isBackgroundBlurEnabled = blurOption !== BlurValues.blurDisabled;
 
   const handleToggle = (): void => {
     if (showRoster) {

--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -14,11 +14,13 @@ import {
   Modal,
   ModalBody,
   ModalHeader,
-  DeviceLabels
+  DeviceLabels,
+  Select
 } from 'amazon-chime-sdk-component-library-react';
 
 import { getErrorContext } from '../../providers/ErrorProvider';
 import routes from '../../constants/routes';
+import { BlurValues } from '../../constants';
 import Card from '../../components/Card';
 import Spinner from '../../components/icons/Spinner';
 import DevicePermissionPrompt from '../DevicePermissionPrompt';
@@ -27,6 +29,13 @@ import { fetchMeeting, createGetAttendeeCallback } from '../../utils/api';
 import { useAppState } from '../../providers/AppStateProvider';
 import { MeetingMode } from '../../types';
 
+const BLUR_OPTIONS = [
+  { value: BlurValues.blurDisabled, label: "Disable Blur" }, 
+  { value: BlurValues.blur10Percent, label: "Blur CPU 10%" }, 
+  { value: BlurValues.blur20Percent, label: "Blur CPU 20%" }, 
+  { value: BlurValues.blur40Percent, label: "Blur CPU 40%" },
+];
+
 const MeetingForm: React.FC = () => {
   const meetingManager = useMeetingManager();
   const {
@@ -34,8 +43,8 @@ const MeetingForm: React.FC = () => {
     region: appRegion,
     meetingId: appMeetingId,
     isWebAudioEnabled,
-    isBackgroundBlurEnabled,
-    toggleBackgroundBlur,
+    blurOption: blurValue,
+    setBlurValue,
     toggleWebAudio,
     setMeetingMode
   } = useAppState();
@@ -162,11 +171,13 @@ const MeetingForm: React.FC = () => {
         infoText="Enable Web Audio to use Voice Focus"
       />
       <FormField
-        field={Checkbox}
-        label="Enable Background Blur"
-        value=""
-        checked={isBackgroundBlurEnabled}
-        onChange={toggleBackgroundBlur}
+        field={Select}
+        options={BLUR_OPTIONS}
+        onChange={(e: ChangeEvent<HTMLSelectElement>): void => {
+          setBlurValue(e.target.value);
+        }}
+        value={blurValue}
+        label="Blur"
       />
       <Flex
         container

--- a/apps/meeting/src/containers/MeetingProviderWrapper/index.tsx
+++ b/apps/meeting/src/containers/MeetingProviderWrapper/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'amazon-chime-sdk-component-library-react';
 
 import routes from '../../constants/routes';
+import { BlurValues } from '../../constants';
 import { NavigationProvider } from '../../providers/NavigationProvider';
 import NoMeetingRedirect from '../NoMeetingRedirect';
 import { Meeting, Home, DeviceSetup } from '../../views';
@@ -18,7 +19,8 @@ import meetingConfig from '../../meetingConfig';
 import { useAppState } from '../../providers/AppStateProvider';
 
 const MeetingProviderWrapper: React.FC = () => {
-  const { isWebAudioEnabled, isBackgroundBlurEnabled } = useAppState();
+  const { isWebAudioEnabled, blurOption } = useAppState();
+  const isBackgroundBlurEnabled = blurOption !== BlurValues.blurDisabled;
 
   const meetingConfigValue = {
     ...meetingConfig,
@@ -57,8 +59,13 @@ const MeetingProviderWrapper: React.FC = () => {
   };
 
   const getMeetingProviderWrapperWithBGBlur = (children: React.ReactNode) => {
+    let filterCPUUtilization = parseInt(blurOption,10);
+    if (!filterCPUUtilization) {
+      filterCPUUtilization = 40;
+    }
+    console.log(`Using ${filterCPUUtilization} CPU utilization for background blur`);
     return (
-      <BackgroundBlurProvider>
+      <BackgroundBlurProvider options={{filterCPUUtilization}} >
         {children}
       </BackgroundBlurProvider>
     );

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -3,6 +3,7 @@
 
 import React, { useContext, useState, ReactNode } from 'react';
 import { MeetingMode, Layout } from '../types';
+import { BlurValues } from '../constants'
 
 type Props = {
   children: ReactNode;
@@ -14,12 +15,12 @@ interface AppStateValue {
   theme: string;
   region: string;
   isWebAudioEnabled: boolean;
-  isBackgroundBlurEnabled: boolean;
+  blurOption: string,
   meetingMode: MeetingMode;
   layout: Layout;
   toggleTheme: () => void;
   toggleWebAudio: () => void;
-  toggleBackgroundBlur: () => void;
+  setBlurValue: (blurValue: string) => void;
   setAppMeetingInfo: (meetingId: string, name: string, region: string) => void;
   setMeetingMode: (meetingMode: MeetingMode) => void;
   setLayout: (layout: Layout) => void;
@@ -37,6 +38,8 @@ export function useAppState(): AppStateValue {
   return state;
 }
 
+
+
 const query = new URLSearchParams(location.search);
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -47,7 +50,7 @@ export function AppStateProvider({ children }: Props) {
   const [layout, setLayout] = useState(Layout.Gallery);
   const [localUserName, setLocalName] = useState('');
   const [isWebAudioEnabled, setIsWebAudioEnabled] = useState(true);
-  const [isBackgroundBlurEnabled, setIsBackgroundBlurEnabled] = useState(true);
+  const [blurOption, setBlur] = useState(BlurValues.blurDisabled);
   const [theme, setTheme] = useState(() => {
     const storedTheme = localStorage.getItem('theme');
     return storedTheme || 'light';
@@ -67,8 +70,8 @@ export function AppStateProvider({ children }: Props) {
     setIsWebAudioEnabled(current => !current);
   }
 
-  const toggleBackgroundBlur = (): void  => {
-    setIsBackgroundBlurEnabled(current => !current);
+  const setBlurValue = (blurValue: string): void  => {
+    setBlur(blurValue);
   }
 
   const setAppMeetingInfo = (
@@ -86,13 +89,13 @@ export function AppStateProvider({ children }: Props) {
     localUserName,
     theme,
     isWebAudioEnabled,
-    isBackgroundBlurEnabled,
+    blurOption,
     region,
     meetingMode,
     layout,
     toggleTheme,
     toggleWebAudio,
-    toggleBackgroundBlur,
+    setBlurValue,
     setAppMeetingInfo,
     setMeetingMode,
     setLayout,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "amazon-chime-sdk",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

This change will update the react meeting app to add blur options to set CPU utilization of background blur. It creates a drop down with the option to disable, 10%, 20%, and 40% utilization.


I have already updated the react component library to pull in the latest JS SDK changes that adds the CPU utilization option to the BackgroundBlurProvider
https://github.com/aws/amazon-chime-sdk-component-library-react/pull/669

It allows builder to set the CPU utilization in the provider options:
```JSX
      <BackgroundBlurProvider options={{filterCPUUtilization:20}} >
        {children}
      </BackgroundBlurProvider>
```

**Testing**

1. How did you test these changes?

I ran the react demo app and confirmed that the blur CPU utilization was successfully set by the drop down.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

Yes. You can run the `apps\meeting` demo app. Before joining the meeting there is an option to select to `Disable Blur` or enable blur by selecting `Blur CPU X%`. You can select 10, 20, or 30 percent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.