### PR TITLE
Conditionally show the background blur checkbox depending on if background blur is enabled

### DIFF
--- a/apps/meeting/src/components/DeviceSelection/CameraDevices/index.tsx
+++ b/apps/meeting/src/components/DeviceSelection/CameraDevices/index.tsx
@@ -12,8 +12,11 @@ import {
 } from 'amazon-chime-sdk-component-library-react';
 
 import { title, StyledInputGroup } from '../Styled';
+import { useAppState } from '../../../providers/AppStateProvider';
+import { BlurValues } from '../../../types';
 
 const CameraDevices = () => {
+  const { blurOption } = useAppState();
   return (
     <div>
       <Heading tag="h2" level={6} css={title}>
@@ -25,9 +28,11 @@ const CameraDevices = () => {
       <StyledInputGroup>
         <QualitySelection />
       </StyledInputGroup>
+      { blurOption !== BlurValues.blurDisabled ?
       <StyledInputGroup>
         <BackgroundBlurCheckbox />
-      </StyledInputGroup>
+      </StyledInputGroup> : ''
+      }
       <Label style={{ display: 'block', marginBottom: '.5rem' }}>
         Video preview
       </Label>


### PR DESCRIPTION

**Issue #:**

**Description of changes:**
Fix a bug where the background blur checkbox was being shown even when background blur was disabled.

**Testing**
ran the test locally and verified the checkbox shows when bg blur is enabled, and doesnt show when disabled. 

1. How did you test these changes?
From the meeting form, disable bg blur, join the meeting, validate that the checkbox is not mounted. 
From the meeting form, enabled bg blur, join the meeting, validate that the checkbox is mounted.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
React meeting demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.