### PR TITLE
 Fix the wrong display style of Zoom In/ Zoom Out label

### DIFF
--- a/apps/meeting/src/containers/Navigation/index.tsx
+++ b/apps/meeting/src/containers/Navigation/index.tsx
@@ -57,25 +57,21 @@ const Navigation: React.FC = () => {
           disabled={!!sharingAttendeeId}
           label="Switch View"
         />
-        <NavbarItem
-          icon={<ZoomIn />}
-          onClick={zoomIn}
-          label="Zoom In"
-          style={{
-            display:
-              layout === Layout.Gallery ? 'flex' : 'none',
-          }}
-          disabled={!!sharingAttendeeId}
-        />
-        <NavbarItem
-          icon={<ZoomOut />}
-          onClick={zoomOut}
-          label="Zoom Out"
-          style={{
-            display:
-              layout === Layout.Gallery ? 'flex' : 'none',
-          }}
-        />
+        {layout === Layout.Gallery &&
+          <>
+            <NavbarItem
+              icon={<ZoomIn />}
+              onClick={zoomIn}
+              label="Zoom In"
+              disabled={!!sharingAttendeeId}
+            />
+            <NavbarItem
+              icon={<ZoomOut />}
+              onClick={zoomOut}
+              label="Zoom Out"
+            />
+          </>
+        }
       </Flex>
       <Flex marginTop="auto">
         <NavbarItem


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Bug: Changing the CSS `display` to `none` only hides the icon itself, the label still displays.
Fix: Instead of changing the CSS `display` to `none`, change the Zoom In/Zoom Out buttons to be rendered conditionally.

**Testing**

1. How did you test these changes?
Run the meeting demo and confirm the fix works.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Yes, meeting demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.