### PR TITLE
Allow to enable simulcast and priority video policies

### DIFF
--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^2.19.2",
         "@typescript-eslint/parser": "^2.19.2",
         "amazon-chime-sdk-component-library-react": "^2.12.0",
-        "amazon-chime-sdk-js": "^2.21.1",
+        "amazon-chime-sdk-js": "^2.24.0",
         "aws-sdk": "^2.731.0",
         "fs-extra": "^10.0.0",
         "react": "^17.0.1",
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.21.1.tgz",
-      "integrity": "sha512-Y8/qabhzIMMvicu/4RAYezFJzBAV0fs4yOD9fCmwdTmNIbq35/X6rpgI8AmpqRNhob1Xv7X/5+elKPYgxhiTfg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.24.0.tgz",
+      "integrity": "sha512-HVdwSlku3BgVRHtwCW875Ii1J3lvvYeF56L6zBCyAGlPWeMDGwwG8BJfb4b3cpSGikR9n8+PzZYJRRFxhgAS+Q==",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",
@@ -11599,9 +11599,9 @@
       }
     },
     "amazon-chime-sdk-js": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.21.1.tgz",
-      "integrity": "sha512-Y8/qabhzIMMvicu/4RAYezFJzBAV0fs4yOD9fCmwdTmNIbq35/X6rpgI8AmpqRNhob1Xv7X/5+elKPYgxhiTfg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.24.0.tgz",
+      "integrity": "sha512-HVdwSlku3BgVRHtwCW875Ii1J3lvvYeF56L6zBCyAGlPWeMDGwwG8BJfb4b3cpSGikR9n8+PzZYJRRFxhgAS+Q==",
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",

--- a/apps/meeting/package.json
+++ b/apps/meeting/package.json
@@ -9,7 +9,7 @@
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
     "amazon-chime-sdk-component-library-react": "^2.12.0",
-    "amazon-chime-sdk-js": "^2.21.1",
+    "amazon-chime-sdk-js": "^2.24.0",
     "aws-sdk": "^2.731.0",
     "fs-extra": "^10.0.0",
     "react": "^17.0.1",

--- a/apps/meeting/src/containers/Navigation/index.tsx
+++ b/apps/meeting/src/containers/Navigation/index.tsx
@@ -26,7 +26,7 @@ import { useVideoTileGridControl } from '../../providers/VideoTileGridProvider';
 
 const Navigation: React.FC = () => {
   const { toggleRoster, closeNavbar } = useNavigation();
-  const { theme, toggleTheme, layout, setLayout } = useAppState();
+  const { theme, toggleTheme, layout, setLayout, priorityBasedPolicy } = useAppState();
   const { sharingAttendeeId } = useContentShareState();
   const { zoomIn, zoomOut } = useVideoTileGridControl();
 
@@ -57,7 +57,7 @@ const Navigation: React.FC = () => {
           disabled={!!sharingAttendeeId}
           label="Switch View"
         />
-        {layout === Layout.Gallery &&
+        {layout === Layout.Gallery && priorityBasedPolicy &&
           <>
             <NavbarItem
               icon={<ZoomIn />}

--- a/apps/meeting/src/meetingConfig.ts
+++ b/apps/meeting/src/meetingConfig.ts
@@ -4,7 +4,6 @@
 import {
   ConsoleLogger,
   LogLevel,
-  VideoPriorityBasedPolicy
 } from 'amazon-chime-sdk-js';
 import { SDK_LOG_LEVELS } from './constants';
 
@@ -27,15 +26,13 @@ const postLogConfig = {
   logLevel: SDK_LOG_LEVELS.info,
 };
 
-const logger = new ConsoleLogger('SDK', LogLevel.INFO);
-export const priorityBasedPolicy = new VideoPriorityBasedPolicy(logger);
+export const logger = new ConsoleLogger('SDK', LogLevel.INFO);
 
 const config = {
   logLevel,
   simulcastEnabled: false,
   postLogConfig,
   logger,
-  videoDownlinkBandwidthPolicy: priorityBasedPolicy,
 };
 
 export default config;

--- a/apps/meeting/src/providers/VideoTileGridProvider/Utils.ts
+++ b/apps/meeting/src/providers/VideoTileGridProvider/Utils.ts
@@ -1,5 +1,10 @@
-import { DefaultModality, TargetDisplaySize, VideoPreference, VideoPreferences } from 'amazon-chime-sdk-js';
-import { priorityBasedPolicy } from '../../meetingConfig';
+import {
+  DefaultModality,
+  TargetDisplaySize,
+  VideoPreference,
+  VideoPreferences,
+  VideoPriorityBasedPolicy
+} from 'amazon-chime-sdk-js';
 import { Layout } from '../../types';
 import { AttendeeState, GridState, VideoSourceState } from './state';
 
@@ -96,8 +101,13 @@ export const calculateVideoSourcesToBeRendered = (
 export const updateDownlinkPreferences = (
   gridState: GridState,
   videoSourceState: VideoSourceState,
-  attendeeStates: { [attendeeId: string]: AttendeeState }
+  attendeeStates: { [attendeeId: string]: AttendeeState },
+  priorityBasedPolicy: VideoPriorityBasedPolicy | undefined
 ): void => {
+
+  if (!priorityBasedPolicy) {
+    return;
+  }
   const { layout, threshold } = gridState;
   const { hasLocalVideo } = videoSourceState;
   const videoPreferences = VideoPreferences.prepare();

--- a/apps/meeting/src/providers/VideoTileGridProvider/index.tsx
+++ b/apps/meeting/src/providers/VideoTileGridProvider/index.tsx
@@ -15,7 +15,6 @@ import {
   VideoSource,
 } from 'amazon-chime-sdk-js';
 import React, { createContext, useContext, useEffect, useReducer } from 'react';
-import { priorityBasedPolicy } from '../../meetingConfig';
 import { Layout } from '../../types';
 import { useAppState } from '../AppStateProvider';
 import {
@@ -30,6 +29,7 @@ const VideoTileGridStateContext = createContext<State | undefined>(undefined);
 const VideoTileGridControlContext = createContext<Controls | undefined>(undefined);
 
 const VideoTileGridProvider: React.FC = ({ children }) => {
+  const { priorityBasedPolicy } = useAppState();
   const meetingManager = useMeetingManager();
   const audioVideo = useAudioVideo();
   const activeSpeakers = useActiveSpeakersState();
@@ -108,7 +108,10 @@ const VideoTileGridProvider: React.FC = ({ children }) => {
     };
 
     priorityBasedPolicy.addObserver(observer);
-
+    dispatch( {
+      type: VideoTileGridAction.SetPriorityBasedPolicy,
+      payload: { policy: priorityBasedPolicy }
+    });
     return (): void => priorityBasedPolicy.removeObserver(observer);
   }, [audioVideo]);
 


### PR DESCRIPTION
**Description of changes:**
- Allow to select simulcast uplink and priority-based downlink policies
- Disable the simulcast in non-Chrome browser and priority-based on Firefox.
- Fix the issue where selecting webAudio or background blur clear out the form.

**Testing**

1. How did you test these changes?
- Join a meeting with 3 videos in Chrome with simulcast and priority-based downlink policies.
- Verify that simulcast is enabled 
- Verify that zoom in and out button only shown when priority-based downlink policy is enabled.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? Yes, the meeting demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.