### PR TITLE
Add '/end' endpoint to webpack-dev-server proxy

### DIFF
--- a/apps/meeting/webpack.config.js
+++ b/apps/meeting/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
   ],
   devServer: {
     proxy: {
-      context: ['/join', '/attendee'],
+      context: ['/join', '/attendee', '/end'],
       target: 'http://127.0.0.1:8080',
     },
     historyApiFallback: {


### PR DESCRIPTION
**Issue #:**

The `endMeetingForAll` button returns 404 error.

**Description of changes:**
Add '/end' endpoint to webpack-dev-server proxy

**Testing**

1. How did you test these changes?
Tested in meeting demo and confirmed the fix can work.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Yes, meeting demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.