### PR TITLE
Fixed Web Audio not being enabled properly, disabled the ability to h…

### DIFF
--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -96,6 +96,7 @@ const MeetingForm: React.FC = () => {
             : DeviceLabels.AudioAndVideo,
         meetingManagerConfig: {
           ...meetingConfig,
+          enableWebAudio: isWebAudioEnabled,
           simulcastEnabled: enableSimulcast,
         },
       });


### PR DESCRIPTION
…ave web audio and disable audio video enabled at once because of a bug and redundant logic

**Issue #:**
There's a bug that prevents Web Audio from being enabled properly, there is also a bug where if a user with WebAudio and Audio and Video disable join start a meeting they will instantly get kicked.
**Description of changes:**
Fixed the bug where Web Audio enabled would not be passed correctly. Prevent the ability to enable both web audio and disable audio video.
**Testing**

1. How did you test these changes?
- Test to confirm you can not enable both web audio and disable audio video.
- Join a meeting as two users with web audio
- Enable voice focus
- Test for voice focus
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Meeting demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.