### PR TITLE
Specify root in eslint config

### DIFF
--- a/apps/meeting/.eslintrc.json
+++ b/apps/meeting/.eslintrc.json
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 {
+  "root": true,
   "env": {
     "browser": true,
     "es2021": true


### PR DESCRIPTION
**Issue #:**
Deploy serverlessly the meeting demo if it is in the same folder as react library will cause this error as eslint tries to search for eslint config in ancestor directory.
```
ESLint: 8.7.0

ESLint couldn't determine the plugin "react" uniquely.

- /home/runner/work/amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react/amazon-chime-sdk/apps/meeting/node_modules/eslint-plugin-react/index.js (loaded in ".eslintrc.json")
- /home/runner/work/amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react/node_modules/eslint-plugin-react/index.js (loaded in "../../../.eslintrc.json")
```
**Description of changes:**
Specify root property to stop this behavior.

**Testing**

1. How did you test these changes? Test locally with amazon-chime-sdk nested under amazon-chime-component-react-library.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.