### PR TITLE
Add keepLastFrameWhenPaused in demo

### DIFF
--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -46,11 +46,13 @@ const MeetingForm: React.FC = () => {
     meetingMode,
     enableSimulcast,
     priorityBasedPolicy,
+    keepLastFrameWhenPaused,
     isWebAudioEnabled,
     videoTransformCpuUtilization: videoTransformCpuUtilization,
     toggleWebAudio,
     toggleSimulcast,
     togglePriorityBasedPolicy,
+    toggleKeepLastFrameWhenPaused,
     setMeetingMode,
     setMeetingId,
     setLocalUserName,
@@ -98,6 +100,8 @@ const MeetingForm: React.FC = () => {
           ...meetingConfig,
           enableWebAudio: isWebAudioEnabled,
           simulcastEnabled: enableSimulcast,
+          videoDownlinkBandwidthPolicy: priorityBasedPolicy,
+          keepLastFrameWhenPaused: keepLastFrameWhenPaused,
         },
       });
       if (meetingMode === MeetingMode.Spectator) {
@@ -211,6 +215,13 @@ const MeetingForm: React.FC = () => {
           onChange={togglePriorityBasedPolicy}
         />
       }
+      <FormField
+        field={Checkbox}
+        label="Keep Last Frame When Paused"
+        value=""
+        checked={keepLastFrameWhenPaused}
+        onChange={toggleKeepLastFrameWhenPaused}
+      />
       <Flex
         container
         layout="fill-space-centered"

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -21,11 +21,13 @@ interface AppStateValue {
   meetingMode: MeetingMode;
   enableSimulcast: boolean;
   priorityBasedPolicy: VideoPriorityBasedPolicy | undefined;
+  keepLastFrameWhenPaused: boolean;
   layout: Layout;
   toggleTheme: () => void;
   toggleWebAudio: () => void;
   toggleSimulcast: () => void;
   togglePriorityBasedPolicy: () => void;
+  toggleKeepLastFrameWhenPaused: () => void;
   setCpuUtilization: (videoTransformCpuUtilization: string) => void;
   setMeetingMode: React.Dispatch<React.SetStateAction<MeetingMode>>;
   setLayout: React.Dispatch<React.SetStateAction<Layout>>;
@@ -61,6 +63,7 @@ export function AppStateProvider({ children }: Props) {
   const [isWebAudioEnabled, setIsWebAudioEnabled] = useState(true);
   const [priorityBasedPolicy, setPriorityBasedPolicy] = useState<VideoPriorityBasedPolicy| undefined>(undefined);
   const [enableSimulcast, setEnableSimulcast] = useState(false);
+  const [keepLastFrameWhenPaused, setKeepLastFrameWhenPaused] = useState(false);
   const [theme, setTheme] = useState(() => {
     const storedTheme = localStorage.getItem('theme');
     return storedTheme || 'light';
@@ -118,6 +121,10 @@ export function AppStateProvider({ children }: Props) {
     }
   };
 
+  const toggleKeepLastFrameWhenPaused = (): void => {
+    setKeepLastFrameWhenPaused(current => !current);
+  };
+
   const setCpuUtilization = (filterValue: string): void => {
     setCpuPercentage(filterValue);
   };
@@ -138,9 +145,11 @@ export function AppStateProvider({ children }: Props) {
     layout,
     enableSimulcast,
     priorityBasedPolicy,
+    keepLastFrameWhenPaused,
     toggleTheme,
     toggleWebAudio,
     togglePriorityBasedPolicy,
+    toggleKeepLastFrameWhenPaused,
     toggleSimulcast,
     setCpuUtilization,
     setMeetingMode,


### PR DESCRIPTION
**Description of changes:**
Add keepLastFrameWhenPaused in demo to test this PR https://github.com/aws/amazon-chime-sdk-component-library-react/pull/721

**Testing**

1. How did you test these changes? Verify that the meeting configuration  
   1. Join a meeting with priority based policy and ``keepLastFrameWhenPaused` selected.
   2.  Throttle the network and make sure that remote videos are paused with last frame.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? Yes, meeting demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.