### PR TITLE
Add amazon-chime-sdk-component-library-react submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "amazon-chime-sdk-component-library-react"]
+	path = amazon-chime-sdk-component-library-react
+	url = git@github.com:aws/amazon-chime-sdk-component-library-react.git

--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -7,13 +7,14 @@
     "": {
       "name": "chime-sdk-meeting-demo",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@types/react": "^16.9.46",
         "@types/react-dom": "^16.9.5",
         "@types/styled-components": "^4.4.2",
         "@types/webpack-env": "^1.15.1",
-        "amazon-chime-sdk-component-library-react": "^2.15.0",
-        "amazon-chime-sdk-js": "^2.26.0",
+        "amazon-chime-sdk-component-library-react": "file:../../amazon-chime-sdk-component-library-react",
+        "amazon-chime-sdk-js": "^3.0.0-beta.1",
         "aws-sdk": "^2.1034.0",
         "fs-extra": "^10.0.0",
         "lodash.isequal": "^4.5.0",
@@ -47,6 +48,157 @@
         "webpack": "^5.64.1",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.5.0"
+      }
+    },
+    "../../amazon-chime-sdk-component-library-react": {
+      "version": "3.0.0-beta.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@popperjs/core": "^2.2.2",
+        "fast-memoize": "^2.5.2",
+        "lodash.isequal": "^4.5.0",
+        "react-popper": "^2.2.4",
+        "throttle-debounce": "^2.3.0",
+        "uuid": "^8.0.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^13.0.0",
+        "@rollup/plugin-node-resolve": "^8.0.1",
+        "@storybook/addon-a11y": "^6.4.18",
+        "@storybook/addon-docs": "^6.4.18",
+        "@storybook/addon-knobs": "^6.4.0",
+        "@storybook/addon-storysource": "^6.4.18",
+        "@storybook/addon-viewport": "^6.4.18",
+        "@storybook/addons": "^6.4.18",
+        "@storybook/react": "^6.4.18",
+        "@storybook/storybook-deployer": "^2.8.10",
+        "@storybook/theming": "^6.4.18",
+        "@testing-library/jest-dom": "^5.11.9",
+        "@testing-library/react": "^11.2.5",
+        "@testing-library/react-hooks": "^7.0.2",
+        "@testing-library/user-event": "^12.8.0",
+        "@types/classnames": "^2.3.1",
+        "@types/jest": "^25.2.1",
+        "@types/lodash.isequal": "^4.5.5",
+        "@types/puppeteer": "^5.4.3",
+        "@types/react": "^17.0.1",
+        "@types/react-dom": "^17.0.1",
+        "@types/react-test-renderer": "^17.0.1",
+        "@types/resize-observer-browser": "^0.1.3",
+        "@types/styled-components": "^5.1.0",
+        "@types/styled-system": "^5.1.9",
+        "@types/testing-library__react": "^10.0.1",
+        "@types/throttle-debounce": "^2.1.0",
+        "@types/uuid": "^7.0.3",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
+        "add": "^2.0.6",
+        "amazon-chime-sdk-js": "^3.0.0-beta.1",
+        "babel-loader": "^8.1.0",
+        "css-loader": "^2.1.1",
+        "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-react": "^7.26.1",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
+        "jest": "^26.6.3",
+        "jest-image-snapshot": "^4.4.0",
+        "jest-puppeteer-docker": "^1.4.2",
+        "mini-css-extract-plugin": "^0.7.0",
+        "postcss-loader": "^3.0.0",
+        "postcss-preset-env": "^6.6.0",
+        "prettier": "^2.4.1",
+        "prompt-sync": "^4.2.0",
+        "puppeteer": "^2.1.1",
+        "react": "^17.0.1",
+        "react-docgen-typescript-loader": "^3.7.2",
+        "react-dom": "^17.0.1",
+        "react-is": "^17.0.0",
+        "resize-observer-polyfill": "^1.5.1",
+        "rimraf": "^2.6.3",
+        "rollup": "^2.26.3",
+        "rollup-plugin-peer-deps-external": "^2.2.2",
+        "rollup-plugin-typescript2": "^0.27.1",
+        "start-server-and-test": "^1.14.0",
+        "storybook": "^6.4.18",
+        "style-loader": "^0.23.1",
+        "styled-components": "^5.1.0",
+        "styled-system": "^5.1.5",
+        "themeprovider-storybook": "^1.8.0",
+        "ts-jest": "^26.5.2",
+        "ts-loader": "^6.0.2",
+        "typescript": "^4.2.1",
+        "url-loader": "^2.0.0",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.2"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^15 || ^16",
+        "npm": "^6 || ^7 || ^8"
+      },
+      "peerDependencies": {
+        "amazon-chime-sdk-js": "^3.0.0-beta.1",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
+        "styled-components": "^5.0.0",
+        "styled-system": "^5.1.5"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
+      "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+      "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
+      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
+      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -434,15 +586,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
-      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1442,37 +1585,20 @@
       }
     },
     "node_modules/amazon-chime-sdk-component-library-react": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-component-library-react/-/amazon-chime-sdk-component-library-react-2.15.0.tgz",
-      "integrity": "sha512-l8korQta0eYVktnNlaILyMm2Slh/TvTvqLaDj6mBhn9dzOUUeZFXkUiCiy1lk30DgrMSwuh/vlAEFWDsm5NJFw==",
-      "dependencies": {
-        "@popperjs/core": "^2.2.2",
-        "fast-memoize": "^2.5.2",
-        "lodash.isequal": "^4.5.0",
-        "react-popper": "^2.2.4",
-        "throttle-debounce": "^2.3.0",
-        "uuid": "^8.0.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || ^15 || ^16",
-        "npm": "^6 || ^7 || ^8"
-      },
-      "peerDependencies": {
-        "amazon-chime-sdk-js": "^2.26.0",
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1",
-        "styled-components": "^5.0.0",
-        "styled-system": "^5.1.5"
-      }
+      "resolved": "../../amazon-chime-sdk-component-library-react",
+      "link": true
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.26.0.tgz",
-      "integrity": "sha512-jOAzozunNrudKIr1O2SXR4vL3PN4JQdtHtcRyaMjUQB6lkrFpxHpqX296Xgh0gTFckgG+aqHGtvn481hjt8Yyg==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.0.0-beta.1.tgz",
+      "integrity": "sha512-8p5bFpwF62PWkf/XnABO6tMOp3CZBcn3Nnr9fO5X+qI4rwdCvr+qVL6Kg1gpN/vGKP888VkzmsaliNcmtUQEvg==",
       "dependencies": {
+        "@aws-crypto/sha256-js": "^2.0.1",
+        "@aws-sdk/util-hex-encoding": "^3.47.0",
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
+        "pako": "^2.0.4",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
@@ -3230,11 +3356,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "node_modules/fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
@@ -5171,6 +5292,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -5927,28 +6053,10 @@
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==",
       "dev": true
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "node_modules/react-popper": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17"
-      }
     },
     "node_modules/react-router": {
       "version": "5.2.1",
@@ -7032,8 +7140,7 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7183,6 +7290,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7205,14 +7313,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -7782,6 +7882,61 @@
     }
   },
   "dependencies": {
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
+      "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
+      "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
+      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
+      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
@@ -8083,11 +8238,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@popperjs/core": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
-      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -8958,26 +9108,96 @@
       "requires": {}
     },
     "amazon-chime-sdk-component-library-react": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-component-library-react/-/amazon-chime-sdk-component-library-react-2.15.0.tgz",
-      "integrity": "sha512-l8korQta0eYVktnNlaILyMm2Slh/TvTvqLaDj6mBhn9dzOUUeZFXkUiCiy1lk30DgrMSwuh/vlAEFWDsm5NJFw==",
+      "version": "file:../../amazon-chime-sdk-component-library-react",
       "requires": {
         "@popperjs/core": "^2.2.2",
+        "@rollup/plugin-commonjs": "^13.0.0",
+        "@rollup/plugin-node-resolve": "^8.0.1",
+        "@storybook/addon-a11y": "^6.4.18",
+        "@storybook/addon-docs": "^6.4.18",
+        "@storybook/addon-knobs": "^6.4.0",
+        "@storybook/addon-storysource": "^6.4.18",
+        "@storybook/addon-viewport": "^6.4.18",
+        "@storybook/addons": "^6.4.18",
+        "@storybook/react": "^6.4.18",
+        "@storybook/storybook-deployer": "^2.8.10",
+        "@storybook/theming": "^6.4.18",
+        "@testing-library/jest-dom": "^5.11.9",
+        "@testing-library/react": "^11.2.5",
+        "@testing-library/react-hooks": "^7.0.2",
+        "@testing-library/user-event": "^12.8.0",
+        "@types/classnames": "^2.3.1",
+        "@types/jest": "^25.2.1",
+        "@types/lodash.isequal": "^4.5.5",
+        "@types/puppeteer": "^5.4.3",
+        "@types/react": "^17.0.1",
+        "@types/react-dom": "^17.0.1",
+        "@types/react-test-renderer": "^17.0.1",
+        "@types/resize-observer-browser": "^0.1.3",
+        "@types/styled-components": "^5.1.0",
+        "@types/styled-system": "^5.1.9",
+        "@types/testing-library__react": "^10.0.1",
+        "@types/throttle-debounce": "^2.1.0",
+        "@types/uuid": "^7.0.3",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
+        "add": "^2.0.6",
+        "amazon-chime-sdk-js": "^3.0.0-beta.1",
+        "babel-loader": "^8.1.0",
+        "css-loader": "^2.1.1",
+        "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-react": "^7.26.1",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "fast-memoize": "^2.5.2",
+        "jest": "^26.6.3",
+        "jest-image-snapshot": "^4.4.0",
+        "jest-puppeteer-docker": "^1.4.2",
         "lodash.isequal": "^4.5.0",
+        "mini-css-extract-plugin": "^0.7.0",
+        "postcss-loader": "^3.0.0",
+        "postcss-preset-env": "^6.6.0",
+        "prettier": "^2.4.1",
+        "prompt-sync": "^4.2.0",
+        "puppeteer": "^2.1.1",
+        "react": "^17.0.1",
+        "react-docgen-typescript-loader": "^3.7.2",
+        "react-dom": "^17.0.1",
+        "react-is": "^17.0.0",
         "react-popper": "^2.2.4",
+        "resize-observer-polyfill": "^1.5.1",
+        "rimraf": "^2.6.3",
+        "rollup": "^2.26.3",
+        "rollup-plugin-peer-deps-external": "^2.2.2",
+        "rollup-plugin-typescript2": "^0.27.1",
+        "start-server-and-test": "^1.14.0",
+        "storybook": "^6.4.18",
+        "style-loader": "^0.23.1",
+        "styled-components": "^5.1.0",
+        "styled-system": "^5.1.5",
+        "themeprovider-storybook": "^1.8.0",
         "throttle-debounce": "^2.3.0",
-        "uuid": "^8.0.0"
+        "ts-jest": "^26.5.2",
+        "ts-loader": "^6.0.2",
+        "typescript": "^4.2.1",
+        "url-loader": "^2.0.0",
+        "uuid": "^8.0.0",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.2"
       }
     },
     "amazon-chime-sdk-js": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.26.0.tgz",
-      "integrity": "sha512-jOAzozunNrudKIr1O2SXR4vL3PN4JQdtHtcRyaMjUQB6lkrFpxHpqX296Xgh0gTFckgG+aqHGtvn481hjt8Yyg==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.0.0-beta.1.tgz",
+      "integrity": "sha512-8p5bFpwF62PWkf/XnABO6tMOp3CZBcn3Nnr9fO5X+qI4rwdCvr+qVL6Kg1gpN/vGKP888VkzmsaliNcmtUQEvg==",
       "requires": {
+        "@aws-crypto/sha256-js": "^2.0.1",
+        "@aws-sdk/util-hex-encoding": "^3.47.0",
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
+        "pako": "^2.0.4",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
@@ -10335,11 +10555,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
@@ -11758,6 +11973,11 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+    },
     "param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -12315,24 +12535,10 @@
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==",
       "dev": true
     },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "react-popper": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
-      "requires": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      }
     },
     "react-router": {
       "version": "5.2.1",
@@ -13177,8 +13383,7 @@
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -13285,7 +13490,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -13303,14 +13509,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "watchpack": {
       "version": "2.3.1",

--- a/apps/meeting/package.json
+++ b/apps/meeting/package.json
@@ -6,8 +6,8 @@
     "@types/react-dom": "^16.9.5",
     "@types/styled-components": "^4.4.2",
     "@types/webpack-env": "^1.15.1",
-    "amazon-chime-sdk-component-library-react": "^2.15.0",
-    "amazon-chime-sdk-js": "^2.26.0",
+    "amazon-chime-sdk-component-library-react": "file:../../amazon-chime-sdk-component-library-react",
+    "amazon-chime-sdk-js": "^3.0.0-beta.1",
     "aws-sdk": "^2.1034.0",
     "fs-extra": "^10.0.0",
     "lodash.isequal": "^4.5.0",
@@ -20,10 +20,13 @@
   },
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx --fix",
-    "build": "npm run lint && webpack --config ./webpack.config.js",
+    "preinstall": "scripts/setup-chime-react-submodule.js",
+    "build:fast": "webpack --config ./webpack.config.js",
+    "build": "npm run lint && npm install && npm run build:fast",
     "start:client": "webpack serve --config ./webpack.config.dev.js",
     "start:backend": "node server.js",
-    "start": "concurrently \"npm run start:client\" \"npm run start:backend\""
+    "start:fast": "concurrently \"npm run start:client\" \"npm run start:backend\"",
+    "start": "npm install && npm run start:fast"
   },
   "devDependencies": {
     "@types/lodash.isequal": "^4.5.5",

--- a/apps/meeting/scripts/setup-chime-react-submodule.js
+++ b/apps/meeting/scripts/setup-chime-react-submodule.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+function spawnOrFail(command, args, options, printOutput = true) {
+  options = {
+    ...options,
+    shell: true
+  };
+  const cmd = spawnSync(command, args, options);
+
+  if (cmd.error) {
+    console.log(`Command ${command} failed with ${cmd.error.code}`);
+    process.exit(255);
+  }
+  const output = cmd.output.toString();
+  if (printOutput) {
+    console.log(output);
+  }
+  if (cmd.status !== 0) {
+    console.log(`Command ${command} failed with exit code ${cmd.status} signal ${cmd.signal}`);
+    console.log(cmd.stderr.toString());
+    process.exit(cmd.status);
+  }
+  return output;
+}
+
+const pjson = require('../package.json');
+
+// No need to setup if we do not depend on submodule
+if (pjson.dependencies['amazon-chime-sdk-component-library-react'] !== 'file:../../amazon-chime-sdk-component-library-react') {
+  return;
+}
+
+process.chdir(path.join(__dirname, '../../../amazon-chime-sdk-component-library-react'));
+
+if (!fs.existsSync('node_modules')) {
+  console.log('Setup amazon-chime-sdk-component-library-react submodule')
+  spawnOrFail('git', [ 'submodule init']);
+  spawnOrFail('git', [ 'submodule update']);
+  spawnOrFail('npm', [ 'install']);
+}
+
+console.log('Building amazon-chime-sdk-component-library-react submodule');
+spawnOrFail('npm', [ 'run build']);
+
+


### PR DESCRIPTION
**Description of changes:**
Add `amazon-chime-sdk-component-library-react` submodule so that the [meeting demo](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting), which is often used to test development changes in `amazon-chime-sdk-component-library-react`, can use the latest changes from the library repo without waiting for npm release.

**Testing**

1. How did you test these changes? Manually run npm command.
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? No

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.