### PR TITLE
Update the meeting demo to adopt to metrics changes

### DIFF
--- a/apps/meeting/src/containers/LocalMediaStreamMetrics/index.tsx
+++ b/apps/meeting/src/containers/LocalMediaStreamMetrics/index.tsx
@@ -120,27 +120,6 @@ export const LocalMediaStreamMetrics: React.FC = () => {
                   : '';
               })}
             />
-            <MetricItem
-              metricName="Frame Height"
-              metricValues={ssrcArray.map(ssrc => {
-                return localVideoStreamMetrics[ssrc]
-                  .videoUpstreamGoogFrameHeight
-                  ? localVideoStreamMetrics[
-                    ssrc
-                  ].videoUpstreamGoogFrameHeight.toString()
-                  : '';
-              })}
-            />
-            <MetricItem
-              metricName="Frame Width"
-              metricValues={ssrcArray.map(ssrc => {
-                return localVideoStreamMetrics[ssrc].videoUpstreamGoogFrameWidth
-                  ? localVideoStreamMetrics[
-                    ssrc
-                  ].videoUpstreamGoogFrameWidth.toString()
-                  : '';
-              })}
-            />
           </MediaStatsList>
         </>
       )}

--- a/apps/meeting/src/containers/VideoStreamMetrics/index.tsx
+++ b/apps/meeting/src/containers/VideoStreamMetrics/index.tsx
@@ -91,26 +91,6 @@ export const VideoStreamMetrics: React.FC<Props> = ({ attendeeId }) => {
               })}
             />
             <MetricItem
-              metricName="Frame Height"
-              metricValues={ssrcArray.map(ssrc => {
-                return isValidMetric(
-                  streamMetric[ssrc].videoDownstreamGoogFrameHeight
-                )
-                  ? streamMetric[ssrc].videoDownstreamGoogFrameHeight.toString()
-                  : '';
-              })}
-            />
-            <MetricItem
-              metricName="Frame Width"
-              metricValues={ssrcArray.map(ssrc => {
-                return isValidMetric(
-                  streamMetric[ssrc].videoDownstreamGoogFrameWidth
-                )
-                  ? streamMetric[ssrc].videoDownstreamGoogFrameWidth.toString()
-                  : '';
-              })}
-            />
-            <MetricItem
               metricName="Bit rate (kbps)"
               metricValues={ssrcArray.map(ssrc => {
                 return isValidMetric(streamMetric[ssrc].videoUpstreamBitrate)
@@ -157,26 +137,6 @@ export const VideoStreamMetrics: React.FC<Props> = ({ attendeeId }) => {
               metricValues={ssrcArray.map(ssrc => {
                 return isValidMetric(streamMetric[ssrc].videoUpstreamFrameWidth)
                   ? streamMetric[ssrc].videoUpstreamFrameWidth.toString()
-                  : '';
-              })}
-            />
-            <MetricItem
-              metricName="Frame Height"
-              metricValues={ssrcArray.map(ssrc => {
-                return isValidMetric(
-                  streamMetric[ssrc].videoUpstreamGoogFrameHeight
-                )
-                  ? streamMetric[ssrc].videoUpstreamGoogFrameHeight.toString()
-                  : '';
-              })}
-            />
-            <MetricItem
-              metricName="Frame Width"
-              metricValues={ssrcArray.map(ssrc => {
-                return isValidMetric(
-                  streamMetric[ssrc].videoUpstreamGoogFrameWidth
-                )
-                  ? streamMetric[ssrc].videoUpstreamGoogFrameWidth.toString()
                   : '';
               })}
             />


### PR DESCRIPTION
**Issue #:**

Some metrics returned by `useMediaStreamMetrics` hook and `useBandwidthMetrics` hook are deprecated, need to remove them from meeting demo.

**Description of changes:**
Removed any components that use `videoUpstreamGoogFrameHeight`, `videoUpstreamGoogFrameWidth`, `videoDownstreamGoogFrameHeight` and `videoDownstreamGoogFrameWidth`.

**Testing**

1. How did you test these changes?
Run meeting demo and manually confirm it works as expected.

3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Yes, meeting demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.