### PR TITLE
Fix hosted region display

### DIFF
--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -51,7 +51,7 @@
       }
     },
     "../../amazon-chime-sdk-component-library-react": {
-      "version": "3.0.0-beta.0",
+      "version": "3.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@popperjs/core": "^2.2.2",

--- a/apps/meeting/src/containers/MeetingDetails/index.tsx
+++ b/apps/meeting/src/containers/MeetingDetails/index.tsx
@@ -7,15 +7,13 @@ import {
   Flex,
   Heading,
   PrimaryButton,
-  useMeetingManager,
 } from 'amazon-chime-sdk-component-library-react';
 
 import { useAppState } from '../../providers/AppStateProvider';
 import { StyledList } from './Styled';
 
 const MeetingDetails = () => {
-  const { meetingId, toggleTheme, theme } = useAppState();
-  const manager = useMeetingManager();
+  const { meetingId, toggleTheme, theme, region } = useAppState();
 
   return (
     <Flex container layout="fill-space-centered">
@@ -30,7 +28,7 @@ const MeetingDetails = () => {
           </div>
           <div>
             <dt>Hosted region</dt>
-            <dd>{manager.meetingRegion}</dd>
+            <dd>{region}</dd>
           </div>
         </StyledList>
         <PrimaryButton

--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -34,9 +34,9 @@ import {MeetingMode, VideoFiltersCpuUtilization} from '../../types';
 import meetingConfig from '../../meetingConfig';
 
 const VIDEO_TRANSFORM_FILTER_OPTIONS = [
-  { value: VideoFiltersCpuUtilization.Disabled, label: 'Disable Video Filter' }, 
-  { value: VideoFiltersCpuUtilization.CPU10Percent, label: 'Video Filter CPU 10%' }, 
-  { value: VideoFiltersCpuUtilization.CPU20Percent, label: 'Video Filter CPU 20%' }, 
+  { value: VideoFiltersCpuUtilization.Disabled, label: 'Disable Video Filter' },
+  { value: VideoFiltersCpuUtilization.CPU10Percent, label: 'Video Filter CPU 10%' },
+  { value: VideoFiltersCpuUtilization.CPU20Percent, label: 'Video Filter CPU 20%' },
   { value: VideoFiltersCpuUtilization.CPU40Percent, label: 'Video Filter CPU 40%' },
 ];
 
@@ -99,6 +99,8 @@ const MeetingForm: React.FC = () => {
         JoinInfo?.Meeting,
         JoinInfo?.Attendee
       );
+
+      setRegion(JoinInfo.Meeting.MediaRegion);
       meetingSessionConfiguration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = enableSimulcast;
       if(priorityBasedPolicy) {
         meetingSessionConfiguration.videoDownlinkBandwidthPolicy = priorityBasedPolicy;

--- a/apps/meeting/src/utils/api.ts
+++ b/apps/meeting/src/utils/api.ts
@@ -11,6 +11,7 @@ export type MeetingFeatures = {
 
 export type CreateMeetingResponse = {
   MeetingFeatures: MeetingFeatures;
+  MediaRegion: string;
 }
 
 export type JoinMeetingInfo = {


### PR DESCRIPTION
**Description of changes:**
- Fix the issue where the hosted region is blank due to the `mediaRegion` is removed from `MeetingManager`.
- Update the submodule commit.
**Testing**

1. How did you test these changes? Manually verified that media region is displayed in the meeting.
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? Yes meeting demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.