### PR TITLE
Add chat components based on DataMessages

### DIFF
--- a/apps/meeting/src/app.tsx
+++ b/apps/meeting/src/app.tsx
@@ -4,13 +4,9 @@
 import React, { FC } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import {
-  lightTheme,
-  NotificationProvider,
-  darkTheme,
-  GlobalStyles,
-} from 'amazon-chime-sdk-component-library-react';
+import { NotificationProvider, GlobalStyles } from 'amazon-chime-sdk-component-library-react';
 
+import { demoLightTheme, demoDarkTheme } from './theme/demoTheme';
 import { AppStateProvider, useAppState } from './providers/AppStateProvider';
 import ErrorProvider from './providers/ErrorProvider';
 import Notifications from './containers/Notifications';
@@ -35,7 +31,7 @@ const Theme: React.FC = ({ children }) => {
   const { theme } = useAppState();
 
   return (
-    <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme}>
+    <ThemeProvider theme={theme === 'light' ? demoLightTheme : demoDarkTheme}>
       <GlobalStyles />
       {children}
     </ThemeProvider>

--- a/apps/meeting/src/constants/index.ts
+++ b/apps/meeting/src/constants/index.ts
@@ -46,9 +46,12 @@ export const VIDEO_INPUT_QUALITY = {
 };
 
 export const SDK_LOG_LEVELS = {
-  'debug': LogLevel.DEBUG,
-  'info': LogLevel.INFO,
-  'warn': LogLevel.WARN,
-  'error': LogLevel.ERROR,
-  'off': LogLevel.OFF,
+  debug: LogLevel.DEBUG,
+  info: LogLevel.INFO,
+  warn: LogLevel.WARN,
+  error: LogLevel.ERROR,
+  off: LogLevel.OFF,
 };
+
+export const DATA_MESSAGE_LIFETIME_MS = 300000;
+export const DATA_MESSAGE_TOPIC = 'ChimeComponentLibraryDataMessage';

--- a/apps/meeting/src/containers/Chat/ChatInput.tsx
+++ b/apps/meeting/src/containers/Chat/ChatInput.tsx
@@ -1,0 +1,34 @@
+import { Input } from 'amazon-chime-sdk-component-library-react';
+import React, { ChangeEvent, useState } from 'react';
+import { useDataMessages } from '../../providers/DataMessagesProvider';
+import { StyledChatInputContainer } from './Styled';
+
+export default function ChatInput() {
+  const [message, setMessage] = useState('');
+  const { sendMessage } = useDataMessages();
+
+  const handleMessageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setMessage(event.target.value);
+  };
+
+  // TODO: Due to mismatch in React versions installed in demo vs the one onKeyPress accepts in component library
+  // there is a problem with KeyboardEvent type here.
+  // For now use, any as type and cast internally to KeyboardEvent.
+  const handleKeyPress = (event: any) => {
+    if ((event as KeyboardEvent).key === 'Enter') {
+      sendMessage(message);
+      setMessage('');
+    }
+  };
+
+  return (
+    <StyledChatInputContainer>
+      <Input
+        value={message}
+        onChange={handleMessageChange}
+        onKeyPress={handleKeyPress}
+        placeholder="Message all attendees"
+      />
+    </StyledChatInputContainer>
+  );
+}

--- a/apps/meeting/src/containers/Chat/Messages.tsx
+++ b/apps/meeting/src/containers/Chat/Messages.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useRef } from 'react';
+import { ChatBubble } from 'amazon-chime-sdk-component-library-react';
+import { useDataMessages } from '../../providers/DataMessagesProvider';
+import { StyledMessages } from './Styled';
+
+export default function Messages() {
+  const { messages } = useDataMessages();
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (messages.length === 0) {
+      return;
+    }
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages.length]);
+
+  const renderMessages = () => {
+    return messages.map((message) => (
+      <ChatBubble
+        variant={message.isSelf ? 'outgoing' : 'incoming'}
+        senderName={message.senderName}
+        key={message.timestamp}
+        marginLeft="1rem"
+        showTail={message.isSelf ? true : false}
+      >
+        {message.message}
+      </ChatBubble>
+    ));
+  };
+
+  return <StyledMessages ref={scrollRef}>{renderMessages()}</StyledMessages>;
+}

--- a/apps/meeting/src/containers/Chat/Styled.tsx
+++ b/apps/meeting/src/containers/Chat/Styled.tsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+
+export const StyledChat = styled.aside`
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    'chat-header'
+    'messages'
+    'chat-input';
+  width: 100%;
+  height: 100%;
+  padding-bottom: 1rem;
+  overflow-y: auto;
+  background-color: ${(props) => props.theme.chat.bgd};
+  box-shadow: 1rem 1rem 3.75rem 0 rgba(0, 0, 0, 0.1);
+  border-top: 0.0625rem solid ${(props) => props.theme.chat.containerBorder};
+  border-left: 0.0625rem solid ${(props) => props.theme.chat.containerBorder};
+  border-right: 0.0625rem solid ${(props) => props.theme.chat.containerBorder};
+  ${({ theme }) => theme.mediaQueries.min.md} {
+    width: ${(props) => props.theme.chat.maxWidth};
+  }
+`;
+
+export const StyledTitle = styled.div<any>`
+  grid-area: chat-header;
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 0.0625rem solid ${(props) => props.theme.chat.headerBorder};
+  .ch-title {
+    font-size: 1rem;
+    color: ${(props) => props.theme.chat.primaryText};
+  }
+  .close-button {
+    margin-left: auto;
+    display: flex;
+    > * {
+      margin-left: 0.5rem;
+    }
+  }
+`;
+
+export const StyledChatInputContainer = styled.div<any>`
+  grid-area: chat-input;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.75rem;
+
+  .ch-input-wrapper {
+    width: 90%;
+
+    .ch-input {
+      width: 100%;
+    }
+  }
+`;
+
+export const StyledMessages = styled.div`
+  grid-area: messages;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  row-gap: 0.5rem;
+`;

--- a/apps/meeting/src/containers/Chat/index.tsx
+++ b/apps/meeting/src/containers/Chat/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Messages from './Messages';
+import ChatInput from './ChatInput';
+import { StyledChat, StyledTitle } from './Styled';
+import { IconButton, Remove } from 'amazon-chime-sdk-component-library-react';
+import { useNavigation } from '../../providers/NavigationProvider';
+
+export default function Chat() {
+  const { toggleChat } = useNavigation();
+
+  return (
+    <StyledChat className="chat">
+      <StyledTitle>
+        <div className="ch-title">Chat</div>
+        <div className="close-button">
+          <IconButton icon={<Remove />} label="Close" onClick={toggleChat} />
+        </div>
+      </StyledTitle>
+      <Messages />
+      <ChatInput />
+    </StyledChat>
+  );
+}

--- a/apps/meeting/src/containers/Navigation/NavigationControl.tsx
+++ b/apps/meeting/src/containers/Navigation/NavigationControl.tsx
@@ -6,14 +6,34 @@ import React from 'react';
 import MeetingRoster from '../MeetingRoster';
 import Navigation from '.';
 import { useNavigation } from '../../providers/NavigationProvider';
+import Chat from '../Chat'
+import { Flex } from 'amazon-chime-sdk-component-library-react';
 
 const NavigationControl = () => {
-  const { showNavbar, showRoster } = useNavigation();
+  const { showNavbar, showRoster, showChat } = useNavigation();
+
+  const view = () => {
+    if (showRoster && showChat) {
+      return (
+        <Flex layout='stack'>
+          <MeetingRoster />
+          <Chat />
+        </Flex>
+      )
+    }
+    if (showRoster) {
+      return <MeetingRoster />;
+    }
+    if (showChat) {
+      return <Chat />;
+    }
+    return null;
+  };
 
   return (
     <>
       {showNavbar ? <Navigation /> : null}
-      {showRoster ? <MeetingRoster /> : null}
+      {view()}
     </>
   );
 };

--- a/apps/meeting/src/containers/Navigation/index.tsx
+++ b/apps/meeting/src/containers/Navigation/index.tsx
@@ -14,6 +14,7 @@ import {
   ZoomIn,
   ZoomOut,
   useContentShareState,
+  Chat,
 } from 'amazon-chime-sdk-component-library-react';
 
 import { useNavigation } from '../../providers/NavigationProvider';
@@ -25,7 +26,7 @@ import FeaturedLayout from '../../components/icons/FeaturedLayout';
 import { useVideoTileGridControl } from '../../providers/VideoTileGridProvider';
 
 const Navigation: React.FC = () => {
-  const { toggleRoster, closeNavbar } = useNavigation();
+  const { toggleRoster, closeNavbar, toggleChat } = useNavigation();
   const { theme, toggleTheme, layout, setLayout, priorityBasedPolicy } = useAppState();
   const { sharingAttendeeId } = useContentShareState();
   const { zoomIn, zoomOut } = useVideoTileGridControl();
@@ -38,6 +39,11 @@ const Navigation: React.FC = () => {
           icon={<Attendees />}
           onClick={toggleRoster}
           label="Attendees"
+        />
+        <NavbarItem
+          icon={<Chat />}
+          onClick={toggleChat}
+          label="Chat"
         />
         <NavbarItem
           icon={

--- a/apps/meeting/src/providers/DataMessagesProvider/index.tsx
+++ b/apps/meeting/src/providers/DataMessagesProvider/index.tsx
@@ -1,0 +1,106 @@
+import { useAudioVideo, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { DataMessage } from 'amazon-chime-sdk-js';
+import React, { useEffect, useReducer, createContext, useContext, FC, useCallback } from 'react';
+import { DATA_MESSAGE_LIFETIME_MS, DATA_MESSAGE_TOPIC } from '../../constants';
+import { useAppState } from '../AppStateProvider';
+import { DataMessagesActionType, initialState, ChatDataMessage, reducer } from './state';
+
+interface DataMessagesStateContextType {
+  sendMessage: (message: string) => void;
+  messages: ChatDataMessage[];
+}
+
+const DataMessagesStateContext = createContext<DataMessagesStateContextType | undefined>(undefined);
+
+export const DataMessagesProvider: FC = ({ children }) => {
+  const { localUserName } = useAppState();
+  const meetingManager = useMeetingManager();
+  const audioVideo = useAudioVideo();
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(() => {
+    if (!audioVideo) {
+      return;
+    }
+    audioVideo.realtimeSubscribeToReceiveDataMessage(DATA_MESSAGE_TOPIC, handler);
+    return () => {
+      audioVideo.realtimeUnsubscribeFromReceiveDataMessage(DATA_MESSAGE_TOPIC);
+    };
+  }, [audioVideo]);
+
+  const handler = useCallback(
+    (dataMessage: DataMessage) => {
+      if (!dataMessage.throttled) {
+        const isSelf =
+          dataMessage.senderAttendeeId === meetingManager.meetingSession?.configuration.credentials?.attendeeId;
+        if (isSelf) {
+          dispatch({
+            type: DataMessagesActionType.ADD,
+            payload: {
+              message: new TextDecoder().decode(dataMessage.data),
+              senderAttendeeId: dataMessage.senderAttendeeId,
+              timestamp: dataMessage.timestampMs,
+              senderName: dataMessage.senderExternalUserId,
+              isSelf: true,
+            },
+          });
+        } else {
+          const data = dataMessage.json();
+          dispatch({
+            type: DataMessagesActionType.ADD,
+            payload: {
+              message: data.message,
+              senderAttendeeId: dataMessage.senderAttendeeId,
+              timestamp: dataMessage.timestampMs,
+              senderName: data.senderName,
+              isSelf: false,
+            },
+          });
+        }
+      } else {
+        console.warn('DataMessage is throttled. Please resend');
+      }
+    },
+    [meetingManager]
+  );
+
+  const sendMessage = useCallback(
+    (message: string) => {
+      if (!meetingManager || !audioVideo) {
+        return;
+      }
+      const payload = { message, senderName: localUserName };
+      audioVideo.realtimeSendDataMessage(DATA_MESSAGE_TOPIC, payload, DATA_MESSAGE_LIFETIME_MS);
+      handler(
+        new DataMessage(
+          Date.now(),
+          DATA_MESSAGE_TOPIC,
+          new TextEncoder().encode(message),
+          meetingManager.meetingSession?.configuration?.credentials?.attendeeId!,
+          localUserName
+        )
+      );
+    },
+    [meetingManager, audioVideo]
+  );
+
+  const value = {
+    sendMessage,
+    messages: state.messages,
+  };
+  return <DataMessagesStateContext.Provider value={value}>{children}</DataMessagesStateContext.Provider>;
+};
+
+export const useDataMessages = (): {
+  sendMessage: (message: string) => void;
+  messages: ChatDataMessage[];
+} => {
+  const meetingManager = useMeetingManager();
+  const context = useContext(DataMessagesStateContext);
+  if (!meetingManager || !context) {
+    throw new Error(
+      'Use useDataMessages hook inside DataMessagesProvider. Wrap DataMessagesProvider under MeetingProvider.'
+    );
+  }
+  return context;
+};

--- a/apps/meeting/src/providers/DataMessagesProvider/state.tsx
+++ b/apps/meeting/src/providers/DataMessagesProvider/state.tsx
@@ -1,0 +1,36 @@
+export interface ChatDataMessage {
+  message: string;
+  senderAttendeeId: string;
+  timestamp: number;
+  senderName: string;
+  isSelf: boolean;
+}
+
+export interface State {
+  messages: ChatDataMessage[];
+}
+
+export enum DataMessagesActionType {
+  ADD,
+}
+
+export interface AddAction {
+  type: DataMessagesActionType.ADD;
+  payload: ChatDataMessage;
+}
+
+export const initialState: State = {
+  messages: [],
+};
+
+export type Action = AddAction;
+
+export function reducer(state: State, action: Action): State {
+  const { type, payload } = action;
+  switch (type) {
+    case DataMessagesActionType.ADD:
+      return { messages: [...state.messages, payload] };
+    default:
+      throw new Error('Incorrect action in DataMessagesProvider reducer');
+  }
+}

--- a/apps/meeting/src/providers/NavigationProvider.tsx
+++ b/apps/meeting/src/providers/NavigationProvider.tsx
@@ -22,6 +22,8 @@ export type NavigationContextType = {
   closeRoster: () => void;
   openNavbar: () => void;
   closeNavbar: () => void;
+  showChat: boolean;
+  toggleChat: () => void;
 };
 
 type Props = {
@@ -37,6 +39,7 @@ const isDesktop = () => window.innerWidth > 768;
 const NavigationProvider = ({ children }: Props) => {
   const [showNavbar, setShowNavbar] = useState(() => isDesktop());
   const [showRoster, setShowRoster] = useState(() => isDesktop());
+  const [showChat, setShowChat] = useState(() => isDesktop());
   const isDesktopView = useRef(isDesktop());
 
   const location = useLocation();
@@ -62,6 +65,7 @@ const NavigationProvider = ({ children }: Props) => {
       if (!isResizeDesktop) {
         setShowNavbar(false);
         setShowRoster(false);
+        setShowChat(false);
       } else {
         setShowNavbar(true);
       }
@@ -95,6 +99,10 @@ const NavigationProvider = ({ children }: Props) => {
     setShowRoster(false);
   };
 
+  const toggleChat = (): void => {
+    setShowChat(!showChat);
+  };
+
   const providerValue = {
     showNavbar,
     showRoster,
@@ -104,6 +112,8 @@ const NavigationProvider = ({ children }: Props) => {
     closeRoster,
     openNavbar,
     closeNavbar,
+    showChat,
+    toggleChat,
   };
   return (
     <NavigationContext.Provider value={providerValue}>

--- a/apps/meeting/src/theme/demoTheme.ts
+++ b/apps/meeting/src/theme/demoTheme.ts
@@ -1,0 +1,38 @@
+import { lightTheme, darkTheme } from 'amazon-chime-sdk-component-library-react';
+
+const { colors: lightThemeColors, shadows: lightThemeShadows } = lightTheme;
+const { colors: darkThemeColors, shadows: darkThemeShadows } = darkTheme;
+
+const chatLightTheme = {
+  title: lightThemeColors.greys.grey100,
+  primaryText: lightThemeColors.greys.grey80,
+  secondaryText: lightThemeColors.greys.grey50,
+  headerBorder: lightThemeColors.greys.grey40,
+  containerBorder: lightThemeColors.greys.grey30,
+  bgd: lightThemeColors.greys.grey10,
+  fgd: lightThemeColors.greys.white,
+  shadow: lightThemeShadows.large,
+  maxWidth: '18.5rem',
+};
+
+const chatDarkTheme = {
+  title: darkThemeColors.greys.white,
+  primaryText: darkThemeColors.greys.white,
+  secondaryText: darkThemeColors.greys.grey20,
+  headerBorder: darkThemeColors.greys.black,
+  containerBorder: darkThemeColors.greys.black,
+  bgd: darkThemeColors.greys.grey100,
+  fgd: darkThemeColors.greys.grey60,
+  shadow: darkThemeShadows.large,
+  maxWidth: '18.5rem',
+};
+
+export const demoLightTheme = {
+  ...lightTheme,
+  chat: chatLightTheme,
+};
+
+export const demoDarkTheme = {
+  ...darkTheme,
+  chat: chatDarkTheme,
+};

--- a/apps/meeting/src/views/Meeting/Styled.ts
+++ b/apps/meeting/src/views/Meeting/Styled.ts
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 interface Props {
   showNav: boolean;
   showRoster: boolean;
+  showChat: boolean;
 }
 
 export const StyledLayout = styled.main<Props>`
@@ -18,11 +19,18 @@ export const StyledLayout = styled.main<Props>`
     grid-area: content;
   }
 
-  ${({ showNav, showRoster }) => {
-    if (showNav && showRoster) {
+  ${({ showNav, showRoster, showChat }) => {
+    if (showNav && (showRoster || showChat)) {
       return `
         grid-template-columns: auto auto 1fr;
-        grid-template-areas: 'nav roster content';
+        grid-template-areas: 'nav side-panel content';
+      `;
+    }
+
+    if (showNav && (showRoster || showChat)) {
+      return `
+        grid-template-columns: auto auto 1fr;
+        grid-template-areas: 'nav side-panel content';
       `;
     }
 
@@ -33,10 +41,10 @@ export const StyledLayout = styled.main<Props>`
       `;
     }
 
-    if (showRoster) {
+    if (showRoster || showChat) {
       return `
         grid-template-columns: auto 1fr;
-        grid-template-areas: 'roster content';
+        grid-template-areas: 'side-panel content';
       `;
     }
 
@@ -50,8 +58,9 @@ export const StyledLayout = styled.main<Props>`
     grid-area: nav;
   }
 
-  .roster {
-    grid-area: roster;
+  .roster,
+  .chat {
+    grid-area: side-panel;
     z-index: 2;
   }
 
@@ -70,7 +79,8 @@ export const StyledLayout = styled.main<Props>`
       position: fixed;
     }
 
-    .roster {
+    .roster,
+    .chat {
       grid-area: unset;
       position: fixed;
       top: 0;
@@ -82,7 +92,8 @@ export const StyledLayout = styled.main<Props>`
   }
 
   @media screen and (max-width: 460px) {
-    .roster {
+    .roster,
+    .chat {
       max-width: 100%;
     }
   }

--- a/apps/meeting/src/views/Meeting/index.tsx
+++ b/apps/meeting/src/views/Meeting/index.tsx
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 import React from 'react';
-import {
-  VideoTileGrid,
-  UserActivityProvider,
-} from 'amazon-chime-sdk-component-library-react';
+import { VideoTileGrid, UserActivityProvider } from 'amazon-chime-sdk-component-library-react';
 
 import { StyledLayout, StyledContent } from './Styled';
 import NavigationControl from '../../containers/Navigation/NavigationControl';
@@ -17,36 +14,31 @@ import DynamicMeetingControls from '../../containers/DynamicMeetingControls';
 import { MeetingMode, Layout } from '../../types';
 import { VideoTileGridProvider } from '../../providers/VideoTileGridProvider';
 import { useAppState } from '../../providers/AppStateProvider';
+import { DataMessagesProvider } from '../../providers/DataMessagesProvider';
 
 const MeetingView = (props: { mode: MeetingMode }) => {
   useMeetingEndRedirect();
-  const { showNavbar, showRoster } = useNavigation();
+  const { showNavbar, showRoster, showChat } = useNavigation();
   const { mode } = props;
   const { layout } = useAppState();
 
   return (
     <UserActivityProvider>
-      <VideoTileGridProvider>
-        <StyledLayout showNav={showNavbar} showRoster={showRoster}>
-          <StyledContent>
-            <VideoTileGrid
-              layout={
-                layout === Layout.Gallery
-                  ? 'standard'
-                  : 'featured'
-              }
-              className="videos"
-              noRemoteVideoView={<MeetingDetails />}
-            />
-            {mode === MeetingMode.Spectator ? (
-              <DynamicMeetingControls />
-            ) : (
-              <MeetingControls />
-            )}
-          </StyledContent>
-          <NavigationControl />
-        </StyledLayout>
-      </VideoTileGridProvider>
+      <DataMessagesProvider>
+        <VideoTileGridProvider>
+          <StyledLayout showNav={showNavbar} showRoster={showRoster} showChat={showChat}>
+            <StyledContent>
+              <VideoTileGrid
+                layout={layout === Layout.Gallery ? 'standard' : 'featured'}
+                className="videos"
+                noRemoteVideoView={<MeetingDetails />}
+              />
+              {mode === MeetingMode.Spectator ? <DynamicMeetingControls /> : <MeetingControls />}
+            </StyledContent>
+            <NavigationControl />
+          </StyledLayout>
+        </VideoTileGridProvider>
+      </DataMessagesProvider>
     </UserActivityProvider>
   );
 };


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- Add DataMessagesProvider to manage the state of messages.
- Add a Messages component to use the messages from DataMessagesProvider
  and show to UI.
- Add demo based light and dark theme to accommodate theme for Chat components.
  This theme is extension of existing component library's themes + chat specific
  theme.
- Adjust Navigation components to support Chat components with responsive UI
  similar to Roster component.
- Show tail for messages from local attendee.
- Show sender names not based on roster rather from just the app state.

**Testing**

1. How did you test these changes?
- Test manually joining same meeting with different attendees.
- Checked for error or warning in console logs.
- Checked message sending and receiving works as expected.
- Tested responsive UI.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
apps/meeting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.