### PR TITLE
Fix the issue that background feature enables camera unexpectedly

### DIFF
--- a/apps/meeting/src/components/DeviceSelection/CameraDevices/VideoTransformDropdown.tsx
+++ b/apps/meeting/src/components/DeviceSelection/CameraDevices/VideoTransformDropdown.tsx
@@ -55,7 +55,7 @@ export const VideoTransformDropdown: React.FC<Props> = ({
   ];
 
   // Creates a device based on the selections (None, Blur, Replacement) and uses it as input.
-  async function selectTransform(e: ChangeEvent<HTMLSelectElement>) {
+  const selectTransform = async (e: ChangeEvent<HTMLSelectElement>) => {
     const selectedTransform = e.target.value;
     let currentDevice = selectedDevice;
 
@@ -86,7 +86,7 @@ export const VideoTransformDropdown: React.FC<Props> = ({
     } finally {
       setIsLoading(false);
     }
-  }
+  };
 
   return (
     <FormField


### PR DESCRIPTION
**Issue #:**
1. `VideoInputTransformControl` starts the camera unexpectedly when calling `resetDeviceToIntrinsic` after mounting.
2. When local video is not enabled, enabling the background feature via `VideoInputTransformControl` drop-down menu will accidentally enable the camera.

**Description of changes:**
1. Use `selectVideoInputDevice` API instead of `startVideoInputDevice` API in `resetDeviceToIntrinsic` function.
2. Change `VideoInputTransformControl` to :
  * call `startVideoInputDevice` if the local video is already enabled
  * call `selectVideoInputDevice` if the local video is not enabled

**Testing**

1. How did you test these changes?
Run the meeting demo and confirm it works as expected.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Yes, meeting demo

2. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
Yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.