### PR TITLE
Chat demo refreshes credentials when expire

### DIFF
--- a/apps/chat/src/providers/AuthProvider.jsx
+++ b/apps/chat/src/providers/AuthProvider.jsx
@@ -78,10 +78,6 @@ const AuthProvider = ({ children }) => {
     }
   };
 
-  function autoRefreshCognitoIAMCreds(creds) {
-
-  }
-
   const getAwsCredentialsFromCognito = async () => {
     const creds = await Auth.currentUserCredentials();
     AWS.config.credentials = new AWS.Credentials(
@@ -90,12 +86,12 @@ const AuthProvider = ({ children }) => {
         creds.sessionToken);
 
     AWS.config.credentials.needsRefresh = function() {
-      return Date.now() > creds.expiration
+      return Date.now() > creds.expiration;
     }
 
     AWS.config.credentials.refresh = function(cb) {
-      console.log("Refresh Cognito IAM Creds")
-      getAwsCredentialsFromCognito().then(cb())
+      console.log("Refresh Cognito IAM Creds");
+      getAwsCredentialsFromCognito().then(cb());
     }
     AWS.config.region = appConfig.region;
     return creds;
@@ -164,9 +160,9 @@ const AuthProvider = ({ children }) => {
 
     const credentialReceiveTime = Date.now();
     // In template.yaml the credential role for anonymous is set to expire in 15 mins
-    var FIFTEEN_MINS = 15 * 60 * 1000;
+    var CREDENTIAL_ROLE_EXPIRY_DURATION = 15 * 60 * 1000;
     AWS.config.credentials.needsRefresh = function() {
-      return Date.now() - credentialReceiveTime > FIFTEEN_MINS
+      return Date.now() - credentialReceiveTime > CREDENTIAL_ROLE_EXPIRY_DURATION
     }
 
     AWS.config.credentials.refresh = function(cb) {

--- a/apps/chat/src/providers/AuthProvider.jsx
+++ b/apps/chat/src/providers/AuthProvider.jsx
@@ -80,6 +80,7 @@ const AuthProvider = ({ children }) => {
 
   function autoRefreshCognitoIAMCreds(creds) {
     creds.needsRefresh = function() {
+      console.log("Cognito needsRefresh: " + Date.now() + " " + creds.expiration)
       return Date.now() > creds.expiration
     }
 
@@ -160,10 +161,11 @@ const AuthProvider = ({ children }) => {
         stsCredentials.SessionToken);
 
 
-    let credentialReceiveTime = Date.now();
-    // In template.yaml the credential role for anon is set to expire in 15 mins
+    const credentialReceiveTime = Date.now();
+    // In template.yaml the credential role for anonymous is set to expire in 15 mins
     var FIFTEEN_MINS = 15 * 60 * 1000;
     AWS.config.credentials.needsRefresh = function() {
+      console.log("Check if credentials need refresh")
       return Date.now() - credentialReceiveTime > FIFTEEN_MINS
     }
 


### PR DESCRIPTION
**Issue #:**

AWS Credentials did not implement refresh behavior and thus all APIs stopped working after they expire (1 hour).   

**Description of changes:**

This change implements refresh behavior for AWS credentials used by Chime Messaging SDK

**Testing**

1. How did you test these changes?

Run the demo for 1 hour both in Cognito signed in user and anonymous user.  For Cognito they refresh, for anonymous throw an console.error saying you need to implement it.  This is because for demo purposes the credential exchange service just gives back a 1 time token to auth, in real use cases it would validate a JWT or something and that could be used to get new credentials.

3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

Yes the chat demo

5. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?

Did not seem applicable, ran in chat folder:

```
$ npm run build
npm ERR! Missing script: "build"
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/daviwith/.npm/_logs/2022-04-27T15_35_32_225Z-debug-0.log
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.