### PR TITLE
Update submodule repository url from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "amazon-chime-sdk-component-library-react"]
 	path = amazon-chime-sdk-component-library-react
-	url = git@github.com:aws/amazon-chime-sdk-component-library-react.git
+	url = https://github.com/aws/amazon-chime-sdk-component-library-react.git


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:**
Currently, `npm install` will fail in forked repository by the following errors:
```
$ git clone https://github.com/simukappu/amazon-chime-sdk.git
$ cd amazon-chime-sdk/apps/meeting
$ npm install

> chime-sdk-meeting-demo@0.1.0 preinstall
> scripts/setup-chime-react-submodule.js

Setup amazon-chime-sdk-component-library-react submodule
,,Submodule 'amazon-chime-sdk-component-library-react' (git@github.com:aws/amazon-chime-sdk-component-library-react.git) registered for path './'

,,Cloning into '<working directory>/amazon-chime-sdk/amazon-chime-sdk-component-library-react'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:aws/amazon-chime-sdk-component-library-react.git' into submodule path '<working directory>/amazon-chime-sdk/amazon-chime-sdk-component-library-react' failed
...
```

If we update submodule repository url of *amazon-chime-sdk-component-library-react* from SSH to HTTPS like this pull request, the build will succeed. Unless there is a specific reason, we would be happy if we could use HTTPS as submodule repository url.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.