### PR TITLE
Enable s3 bucket versioning for televisit demo

### DIFF
--- a/apps/televisit-demo/backend/template.yaml
+++ b/apps/televisit-demo/backend/template.yaml
@@ -344,10 +344,17 @@ Resources:
     Type: 'AWS::S3::Bucket'
     Properties:
       AccessControl: LogDeliveryWrite
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+        IgnorePublicAcls: True
+        RestrictPublicBuckets: True
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
 
   ChatAttachmentsBucketPolicy:
     Type: 'AWS::S3::BucketPolicy'

--- a/apps/televisit-demo/frontend/template.yaml
+++ b/apps/televisit-demo/frontend/template.yaml
@@ -28,6 +28,8 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
 
   s3WebsiteBucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
**Issue #:**

In order to resolve an app sec finding.

**Description of changes:**

Enable s3 bucket versioning for televisit demo

**Testing**

1. How did you test these changes?

needs to be deployed

3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

n/a

5. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?

yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.