### PR TITLE
Prevent creating user/none in chat demo

### DIFF
--- a/apps/chat/src/backend/serverless/template.yaml
+++ b/apps/chat/src/backend/serverless/template.yaml
@@ -476,6 +476,7 @@ Resources:
             if (userId === 'none') {
               console.log(`User hasn't logged in yet and hasn't been setup with profile`);
               callback(null, event);
+              return;
             }
             // Create a Chime App Instance User for the user
             const chimeCreateAppInstanceUserParams = {


### PR DESCRIPTION
**Issue #:**

Prevent creating user/none in chat demo.  There lack of a return was resulting in a user/none being created that is never used

**Description of changes:**

**Testing**

1. How did you test these changes?

Ran app and created new user and logged in.

3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
4. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.