### PR TITLE
fix user auth flow bug; disable cloudfront cache to support dynamic assets

### DIFF
--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -9,7 +9,7 @@
     "sam:build": "cd src/backend/serverless && sam build && cd - ",
     "sam:deploy:backend": "cd src/backend/serverless && sam deploy --resolve-s3 --no-fail-on-empty-changeset && aws cloudformation describe-stacks --stack-name chime-sdk-chat-demo --query 'Stacks[0].Outputs' --output json > appconfig.json && cd - ",
     "sam:deploy:assets": "aws s3 cp dist s3://$(aws cloudformation describe-stacks --stack-name chime-sdk-chat-demo --query \"Stacks[0].Outputs[?OutputKey=='assetsS3BucketName'].OutputValue\" --output text) --recursive",
-    "deploy": "npm run build && npm run sam:build && npm run sam:deploy:backend && npm run sam:deploy:assets"
+    "deploy": "npm run sam:deploy:backend && npm run build && npm run sam:build && npm run sam:deploy:assets"
   },
   "dependencies": {
     "@aws-amplify/auth": "^4.3.20",

--- a/apps/chat/src/backend/serverless/template.yaml
+++ b/apps/chat/src/backend/serverless/template.yaml
@@ -1440,13 +1440,10 @@ Resources:
         DefaultRootObject: chat.html
         DefaultCacheBehavior:
           AllowedMethods:
-            - DELETE
             - GET
             - HEAD
             - OPTIONS
-            - PATCH
-            - POST
-            - PUT
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad # Managed-CachingDisabled
           TargetOriginId: !Ref DemoName
           ForwardedValues:
             QueryString: true


### PR DESCRIPTION
**Issue #:** related : https://github.com/aws-samples/amazon-chime-sdk/issues/224

**Description of changes:**
- fix user auth issue caused by blank app config params. 
- disable cloudfront cache to support dynamic assets

**Testing**

1. How did you test these changes? 
- Run `npm run deploy`
- Create users and attempt to login. login should succeed and no cognito/auth errors due to blank user pool ids should be seen.
4. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? yes, chat demo app.
5. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors? yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.