### PR TITLE
Restrict CORS to cloudfront and localhost origins; upgrade nodejs to 14.x

### DIFF
--- a/apps/chat/README.md
+++ b/apps/chat/README.md
@@ -19,13 +19,8 @@ cd apps/chat
 npm run deploy
 ```
 
-3. Run app locally
-```bash
-   npm start
-```
-
-4. Open https://localhost:9000 in your browser.
-
+3. Now you can access the app via the CloudFront endpoint found in the CloudFormation stack outputs. The stack outputs will be exported to
+   `src/backend/serverless/appconfig.json`.
 
 ### Using the AWS CloudFormation console
 Alternatively, you can deploy backend and frontend manually:
@@ -53,7 +48,7 @@ After the deployment is complete, the **Outputs** tab of the AWS CloudFormation 
    npm install
    npm start
    ```
-1. Open https://localhost:9000 in your browser.
+1. Open [http://localhost:9000](http://localhost:9000/) in your browser.
 1. By default, the demo uses the [Amazon Cognito](https://aws.amazon.com/cognito/) User Pools to manage users. Alternatively, you can get credentials using the [AWS Lambda](https://aws.amazon.com/lambda/) function that the AWS CloudFormation template created in the previous section.
 
     If you prefer to use the default Cognito, continue to the [Cognito User Pools](#cognito-user-pools) section.
@@ -66,7 +61,7 @@ After the deployment is complete, the **Outputs** tab of the AWS CloudFormation 
 
 New users can register through the Amazon Chime SDK Chat Demo.
 
-1. Open [http://localhost:9000](http://localhost:9000/) in your browser.
+1. Open the demo app in your browser.
 1. Provide the username and password for a new user.
 1. Choose **Register**.
 1. The user must confirm the account before signing in to the demo. Follow the steps in the next section to confirm.
@@ -83,7 +78,7 @@ New users can register through the Amazon Chime SDK Chat Demo.
 
 ### Signing in
 
-1. Open [http://localhost:9000](http://localhost:9000/) in your browser.
+1. Open the demo app in your browser.
 1. Provide the username and password of the desired user.
 1. Choose **Sign in**.
 
@@ -91,7 +86,7 @@ Skip to [Creating a Channel](#creating-a-channel)
 
 ## Credential Exchange Service
 
-1. Open [http://localhost:9000](http://localhost:9000/) in your browser.
+1. Open the demo app in your browser.
 1. Change the drop down to **Credential Exchange Service**.
 1. The Credential Exchange Service is a small [AWS Lambda](https://aws.amazon.com/lambda/) function running behind [Amazon API Gateway](https://aws.amazon.com/api-gateway/) that enables exchanging your application's or identity provider's (IDP) token for AWS credentials, or for you to implement custom authentication.
 

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -6,10 +6,10 @@
     "lint": "eslint src --ext .js,.jsx --fix",
     "build": "rm -rf dist && webpack build",
     "start": "webpack serve",
-    "sam:build": "cd src/backend/serverless && sam build && cd - ",
-    "sam:deploy:backend": "cd src/backend/serverless && sam deploy --resolve-s3 --no-fail-on-empty-changeset && aws cloudformation describe-stacks --stack-name chime-sdk-chat-demo --query 'Stacks[0].Outputs' --output json > appconfig.json && cd - ",
-    "sam:deploy:assets": "aws s3 cp dist s3://$(aws cloudformation describe-stacks --stack-name chime-sdk-chat-demo --query \"Stacks[0].Outputs[?OutputKey=='assetsS3BucketName'].OutputValue\" --output text) --recursive",
-    "deploy": "npm run sam:deploy:backend && npm run build && npm run sam:build && npm run sam:deploy:assets"
+    "sam:build": "cd src/backend/serverless && rm -rf .aws-sam && sam build && cd - ",
+    "sam:deploy:backend": "npm run sam:build && cd src/backend/serverless && sam deploy --resolve-s3 --no-fail-on-empty-changeset && aws cloudformation describe-stacks --stack-name chime-sdk-chat-demo --query 'Stacks[0].Outputs' --output json > appconfig.json && cd - ",
+    "sam:deploy:assets": "npm run build && aws s3 cp dist s3://$(aws cloudformation describe-stacks --stack-name chime-sdk-chat-demo --query \"Stacks[0].Outputs[?OutputKey=='assetsS3BucketName'].OutputValue\" --output text) --recursive",
+    "deploy": "npm run sam:deploy:backend && npm run sam:deploy:assets"
   },
   "dependencies": {
     "@aws-amplify/auth": "^4.3.20",

--- a/apps/chat/src/backend/serverless/template.yaml
+++ b/apps/chat/src/backend/serverless/template.yaml
@@ -1,5 +1,3 @@
-#NOTE: In a production environment, we recommend that you use a specific origin for the `Access-Control-Allow-Origin` response header
-#to scope-down access to resources.
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: "AWS::Serverless-2016-10-31"
 Description: AWS CloudFormation stack to set up infrastructure required for the Amazon Chime SDK chat demo app
@@ -42,7 +40,7 @@ Resources:
     Description: The AWS SDK with support for Amazon Chime SDK messaging features.
     Properties:
       CompatibleRuntimes:
-        - "nodejs12.x"
+        - nodejs14.x
       Content:
         S3Bucket: aws-blog-business-productivity-chime-sdk
         S3Key: chat-sdk-demo/aws-sdk-chime-layer.zip
@@ -62,7 +60,7 @@ Resources:
           S3Key: ChannelFlowProfanityDLPProcessor.zip
       MemorySize: 128
       Role: !GetAtt ProcessorLambdaRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: nodejs14.x
       Timeout: 30
       Layers:
         - !Ref AWSSDKChimeLayer
@@ -84,7 +82,7 @@ Resources:
           S3Key: presence-demo-assets/custom-presence-channel-processor.zip
       MemorySize: 128
       Role: !GetAtt PresenceProcessorLambdaRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: nodejs14.x
       Timeout: 30
       Layers:
         - !Ref AWSSDKChimeLayer
@@ -187,7 +185,7 @@ Resources:
           PROCESSOR_LAMBDA_ARN: !GetAtt ProfanityAndDLPProcessor.Arn
           PRESENCE_PROCESSOR_LAMBDA_ARN: !GetAtt PresenceProcessor.Arn
       Role: !GetAtt LambdaExecuteRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: nodejs14.x
       Timeout: 60
       Layers:
         - !Ref AWSSDKChimeLayer
@@ -300,7 +298,7 @@ Resources:
     Properties:
       Handler: "index.handler"
       Role: !GetAtt LambdaExecuteRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: nodejs14.x
       Timeout: 60
       Layers:
         - !Ref AWSSDKChimeLayer
@@ -452,7 +450,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${DemoName}-SignInHook
       Handler: "index.handler"
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       MemorySize: 512
       Role: !GetAtt LambdaExecuteRole.Arn
       Layers:
@@ -901,15 +899,142 @@ Resources:
                   - "chime:DescribeAppInstanceUser"
                 Resource:
                   - !Join ['', [!GetAtt TriggerChimeAppInstanceLambda.AppInstanceArn, '/user/*']]
+
+  PreflightRequestLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          exports.handler = function(event, context, callback) {
+            let origin = 'https://localhost:9000';
+            if (event.headers["origin"]?.match(/cloudfront.net$/)) {
+                origin = event.headers.origin;
+            }
+            callback(null, {
+              statusCode: 200,
+              headers: {
+                  "Access-Control-Allow-Origin" : origin,
+                  "Access-Control-Allow-Credentials": "true",
+                  "Access-Control-Allow-Methods": "OPTIONS,POST",
+                  'Access-Control-Allow-Headers': 'Authorization',
+              },
+            })
+          }
+      Handler: index.handler
+      Role:
+        Fn::GetAtt:
+          - LambdaExecuteRole
+          - Arn
+      Runtime: nodejs14.x
+      Timeout: 60
+
+  PreflightRequestLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      Principal: apigateway.amazonaws.com
+      FunctionName:
+        Ref: PreflightRequestLambda
+      SourceArn:
+        Fn::Sub: arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGatewayApi}/*/OPTIONS/*
+
   ApiGatewayApi:
     Type: AWS::Serverless::Api
     Properties:
+      Description: "Amazon Chime SDK Chat Demo APIs"
       StageName: prod
-      Cors:
-        AllowMethods: "'POST, OPTIONS'"
-        AllowHeaders: "'Authorization'"
-        AllowOrigin: "'*'"
-        MaxAge: "'600'"
+      DefinitionBody:
+        swagger: "2.0"
+        info:
+          version: "1.0"
+          title: "chime-sdk-chat-demo"
+        schemes:
+          - "https"
+        paths:
+          /create:
+            post:
+              responses: { }
+              x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${CreateMeetingApiFunction}/invocations
+                passthroughBehavior: "when_no_match"
+            options:
+              responses: { }
+              x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${PreflightRequestLambda}/invocations
+                responses:
+                  default:
+                    statusCode: "200"
+                passthroughBehavior: "when_no_match"
+                contentHandling: "CONVERT_TO_TEXT"
+          /creds:
+            post:
+              responses: { }
+              x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${CredApiFunction}/invocations
+                passthroughBehavior: "when_no_match"
+            options:
+              responses: { }
+              x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${PreflightRequestLambda}/invocations
+                responses:
+                  default:
+                    statusCode: "200"
+                passthroughBehavior: "when_no_match"
+                contentHandling: "CONVERT_TO_TEXT"
+          /end:
+            post:
+              responses: { }
+              x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${EndMeetingApiFunction}/invocations
+                passthroughBehavior: "when_no_match"
+            options:
+              responses: { }
+              x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${PreflightRequestLambda}/invocations
+                responses:
+                  default:
+                    statusCode: "200"
+                passthroughBehavior: "when_no_match"
+                contentHandling: "CONVERT_TO_TEXT"
+          /join:
+            post:
+              responses: { }
+              x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${CreateAttendeeApiFunction}/invocations
+                passthroughBehavior: "when_no_match"
+            options:
+              responses: { }
+              x-amazon-apigateway-integration:
+                type: "aws_proxy"
+                httpMethod: "POST"
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${PreflightRequestLambda}/invocations
+                responses:
+                  default:
+                    statusCode: "200"
+                passthroughBehavior: "when_no_match"
+                contentHandling: "CONVERT_TO_TEXT"
 
   CredApiFunction: # Adds a POST api endpoint at "/creds" to the ApiGatewayApi via an Api event
     Type: AWS::Serverless::Function
@@ -930,7 +1055,7 @@ Resources:
           AnonUserRole: !GetAtt AuthLambdaAnonUserRole.Arn
       Layers:
         - !Ref AWSSDKChimeLayer
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Handler: index.handler
       InlineCode: |
         // Lambda that validates user tokens and returns AWS Creds for access to chime, scoped to that user
@@ -991,6 +1116,11 @@ Resources:
 
         // MAIN, call above in order
         exports.handler = async event => {
+          let origin = 'https://localhost:9000';
+          if (event.headers["origin"]?.match(/cloudfront.net$/)) {
+             origin = event.headers.origin;
+          }
+
           const method = event.httpMethod;
           const { path } = event;
           const authToken = event.headers.Authorization;
@@ -1007,7 +1137,7 @@ Resources:
                 statusCode: 200,
                 headers: {
                   'Access-Control-Allow-Headers': 'Authorization',
-                  'Access-Control-Allow-Origin': '*',
+                  'Access-Control-Allow-Origin': origin,
                   'Access-Control-Allow-Methods': 'POST, OPTIONS',
                   'Access-Control-Allow-Credentials': 'true'
                 },
@@ -1028,7 +1158,7 @@ Resources:
             statusCode: 401,
             headers: {
               'Access-Control-Allow-Headers': 'Authorization',
-              'Access-Control-Allow-Origin': '*',
+              'Access-Control-Allow-Origin': origin,
               'Access-Control-Allow-Methods': 'POST, OPTIONS',
               'Access-Control-Allow-Credentials': 'true'
             },
@@ -1057,7 +1187,7 @@ Resources:
           ChimeAppInstanceArn: !GetAtt TriggerChimeAppInstanceLambda.AppInstanceArn
       Layers:
         - !Ref AWSSDKChimeLayer
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -1072,6 +1202,11 @@ Resources:
         const appInstanceUserArnHeader = 'x-amz-chime-bearer';
 
         exports.handler = async event => {
+          let origin = 'https://localhost:9000';
+          if (event.headers["origin"]?.match(/cloudfront.net$/)) {
+             origin = event.headers.origin;
+          }
+
           const { userId, channel, name } = event.queryStringParameters;
           const region = 'us-east-1';
 
@@ -1092,7 +1227,7 @@ Resources:
               statusCode: 404,
               headers: {
                 'Access-Control-Allow-Headers': 'Authorization',
-                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Origin': origin,
                 'Access-Control-Allow-Methods': 'POST, OPTIONS',
                 'Access-Control-Allow-Credentials': 'true'
               },
@@ -1118,7 +1253,7 @@ Resources:
               statusCode: 403,
               headers: {
                 'Access-Control-Allow-Headers': 'Authorization',
-                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Origin': origin,
                 'Access-Control-Allow-Methods': 'POST, OPTIONS',
                 'Access-Control-Allow-Credentials': 'true'
               },
@@ -1150,7 +1285,7 @@ Resources:
             statusCode: 200,
             headers: {
               'Access-Control-Allow-Headers': 'Authorization',
-              'Access-Control-Allow-Origin': '*',
+              'Access-Control-Allow-Origin': origin,
               'Access-Control-Allow-Methods': 'POST, OPTIONS',
               'Access-Control-Allow-Credentials': 'true'
             },
@@ -1175,7 +1310,7 @@ Resources:
           ChimeAppInstanceArn: !GetAtt TriggerChimeAppInstanceLambda.AppInstanceArn
       Layers:
         - !Ref AWSSDKChimeLayer
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -1190,6 +1325,11 @@ Resources:
         const appInstanceUserArnHeader = 'x-amz-chime-bearer';
 
         exports.handler = async event => {
+          let origin = 'https://localhost:9000';
+          if (event.headers["origin"]?.match(/cloudfront.net$/)) {
+             origin = event.headers.origin;
+          }
+
           const { userId, channel, name, meeting } = event.queryStringParameters;
           const region = 'us-east-1';
 
@@ -1210,7 +1350,7 @@ Resources:
               statusCode: 404,
               headers: {
                 'Access-Control-Allow-Headers': 'Authorization',
-                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Origin': origin,
                 'Access-Control-Allow-Methods': 'POST, OPTIONS',
                 'Access-Control-Allow-Credentials': 'true'
               },
@@ -1236,7 +1376,7 @@ Resources:
               statusCode: 403,
               headers: {
                 'Access-Control-Allow-Headers': 'Authorization',
-                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Origin': origin,
                 'Access-Control-Allow-Methods': 'POST, OPTIONS',
                 'Access-Control-Allow-Credentials': 'true'
               },
@@ -1263,7 +1403,7 @@ Resources:
             statusCode: 200,
             headers: {
               'Access-Control-Allow-Headers': 'Authorization',
-              'Access-Control-Allow-Origin': '*',
+              'Access-Control-Allow-Origin': origin,
               'Access-Control-Allow-Methods': 'POST, OPTIONS',
               'Access-Control-Allow-Credentials': 'true'
             },
@@ -1288,7 +1428,7 @@ Resources:
           ChimeAppInstanceArn: !GetAtt TriggerChimeAppInstanceLambda.AppInstanceArn
       Layers:
         - !Ref AWSSDKChimeLayer
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -1304,11 +1444,16 @@ Resources:
           })
           .promise();
 
+          let origin = 'https://localhost:9000';
+          if (event.headers["origin"]?.match(/cloudfront.net$/)) {
+             origin = event.headers.origin;
+          }
+
           return {
             statusCode: 200,
             headers: {
               'Access-Control-Allow-Headers': 'Authorization',
-              'Access-Control-Allow-Origin': '*',
+              'Access-Control-Allow-Origin': origin,
               'Access-Control-Allow-Methods': 'POST, OPTIONS',
               'Access-Control-Allow-Credentials': 'true'
             },
@@ -1478,7 +1623,7 @@ Outputs:
   attachmentsS3BucketName:
     Value: !Ref ChatAttachmentsBucket
   apiGatewayInvokeUrl:
-    Value: !Sub https://${ApiGatewayApi}.execute-api.us-east-1.amazonaws.com/Stage/
+    Value: !Sub https://${ApiGatewayApi}.execute-api.us-east-1.amazonaws.com/prod/
   pinpointApplicationArn:
     Condition: PushNotificationEnabled
     Value: !GetAtt PinpointApplication.Arn


### PR DESCRIPTION
Restrict CORS to cloudfront and localhost origins; upgrade nodejs to 14.x

**Issue #:** 
https://github.com/aws-samples/amazon-chime-sdk/issues/224

**Description of changes:**

Restrict CORS to CloudFront and localhost origins; 
- This addresses the sign in with credential exchange service issue mentioned in https://github.com/aws-samples/amazon-chime-sdk/issues/224

Upgrade nodejs to 14.x for the lambdas
- this is to match the min required nodejs version (which is 14.x) described in the readme.
- also the new preflight request lambda code requires `nodejs 14.x`

Update ReadMe accordingly

**Testing**

1. How did you test these changes?
Tested the chat demo app with the following steps:
- Run `npm run deploy` to deploy the demo app backend and frontend resources
- Open the CloudFront endpoint in a browser
- Sign in with `Credential Exchange Service` option and it succeeds. Able to create a channel
- Sign in with Cognito also works
- Create meetings in a channel also works

3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? Yes, the chat demo app

5. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors? yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.