### PR TITLE
Fix for s3 bucket name for chat demo when using attachments

### DIFF
--- a/apps/chat/src/Config.js
+++ b/apps/chat/src/Config.js
@@ -11,6 +11,6 @@ const appConfig = {
     cognitoIdentityPoolId: '' || appConfigJson.cognitoIdentityPoolId,
     appInstanceArn: '' || appConfigJson.appInstanceArn,
     region: 'us-east-1',  // Only supported region for Amazon Chime SDK Messaging as of this writing
-    attachments_s3_bucket_name: '' || appConfigJson.attachments_s3_bucket_name
+    attachments_s3_bucket_name: '' || appConfigJson.attachmentsS3BucketName
 };
 export default appConfig;


### PR DESCRIPTION
**Issue #:224**

**Description of changes: The s3 attachments bucket property was incorrectly referenced.**

**Testing**

1. How did you test these changes?
- Ran the build steps and confirmed attachments are now working out of the box.
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
- Yes, using the chat demo application
3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
- N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.