### PR TITLE
Fix type error when running tsc in meeting demo

### DIFF
--- a/apps/meeting/src/containers/MeetingJoinDetails.tsx
+++ b/apps/meeting/src/containers/MeetingJoinDetails.tsx
@@ -33,7 +33,7 @@ const MeetingJoinDetails = () => {
       history.push(`${routes.MEETING}/${meetingId}`);
     } catch (error) {
       setIsLoading(false);
-      setError(error.message);
+      setError((error as Error).message);
     }
   };
 

--- a/apps/meeting/src/containers/SIPMeeting/index.tsx
+++ b/apps/meeting/src/containers/SIPMeeting/index.tsx
@@ -34,7 +34,7 @@ const SIPMeeting: React.FC = () => {
         updateErrorMessage('Could not generate SIPURI');
       }
     } catch (error) {
-      updateErrorMessage(error.message);
+      updateErrorMessage((error as Error).message);
     }
   };
 


### PR DESCRIPTION
**Issue #:**
When running `tsc` to compile typescript, there're errors regarding the type of `error` in `catch` block.

**Description of changes:**
* Cast the `error` to `Error` in `try catch` block

**Testing**

1. How did you test these changes? 
Run `tsc` and confirm there's no error after change.
Make sure meeting demo works after change.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? Yes, meeting demo.

3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
Yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.