### PR TITLE
Add Alexa skill calling sample skill

### DIFF
--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/README.md
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/README.md
@@ -1,0 +1,178 @@
+# Sample Customer Service Alexa Skill
+
+Amazon Chime SDK Alexa skill calling allows enterprise customers to enable calling directly in their Amazon
+Alexa Skills. In this tutorial, we build an Alexa skill that allows a customer to place a call to a
+customer support.
+
+## Prerequisites
+
+For this walk-through, you should have the following pre-requisites:
+
+- An [AWS account](https://aws.amazon.com/free/) with [administrator access](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started_create-admin-group.html).
+- An [Alexa Developer Console](https://developer.amazon.com/alexa/console/ask) account.
+- An Alexa enabled device that can place phone calls.
+
+## Getting started
+
+### Import Alexa calling skill
+
+Use the following guide to create an Alexa skill by importing the provided sample Alexa skill.
+
+#### To create an Alexa skill in Alexa Developer Console
+
+Use the following steps to create an Alexa skill. Once your skill is created,
+you can import the Alexa skill AWS Lambda and interaction model for your Alexa skill.
+
+1. Log into [Alexa Developer Console](https://developer.amazon.com/alexa/console/ask) with your account.
+2. Choose the **Create Skill**
+3. Provide a skill name. e.g. **My Customer Support**
+4. Select **Custom** For **Choose a model to add to your skill**
+5. Select **Alexa-hosted (Node.js)** for **Choose a method to host your skill's backend resources**
+6. Choose **Create Skill**
+7. Select **Start from Scratch** for **Choose a template to add to your skill**
+8. Choose **Continue with template**
+
+#### To import sample skill
+
+Use the following steps to import the Alexa skill AWS Lambda for your Alexa skill.
+
+1. Find the Alexa skill in apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill folder in the provided sample code package.
+2. Update "placeholder" destinationPhoneNumber and sourcePhoneNumber in the `apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/config.js`.
+   The phone number must be in E.164 phone number format. For example, "+12065551111".
+3. Zip the `apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill` folder into a zip file.
+   Within the `apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill` folder,
+   execute this command **zip -r sample-alexa-skill-lambda.zip sample-alexa-skill-lambda**
+4. In the Alexa Developer Console of your newly created skill, choose tab **Code**, then **Import Code**, and then Select the zip folder of this package
+5. Choose **Next** and then select the **simple-customer-support-skill** folder
+6. Choose **Next** and then **Import**.
+7. After the **Import** is done, choose **Deploy** to deploy the AWS Lambda for your Alexa skill.
+
+#### To import interaction model
+
+Use the following steps to import the Alexa skill interaction model.
+
+1. Within Alexa Developer Console, choose your newly created skill.
+2. Choose **Build**. Choose **Select Interaction Model** and then **Intents**. Choose **JSON Editor** and then **Drag and Drop**
+3. Select the file in `apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/interactionModels/custom/en-US.json` file in the provided sample code package.
+4. Choose **Save Model** and then choose **Build Model**.
+5. After the build finish, you should see a new Intents created in the **Interaction Model** drop down.
+
+### Create Amazon Chime SDK PSTN Audio SIP media application (SMA)
+
+Use the following guide to create a SMA application by importing the provided sample SMA application.
+
+#### To provision phone number for SMA
+
+You are now provisioning a phone number for your SMA application. Your Alexa skill will call this newly provisioned phone number. Here are the steps.
+
+1. Open the Amazon Chime SDK console at https://console.aws.amazon.com/chime-sdk/home.
+2. Choose **Phone number management**, then **Order**, then **Provision phone numbers** and then **SIP Media Application Dial-In** and choose **Next**
+3. Select **Local** as the **Type**. Select a state, for example, **California**. Choose the magnify glass to search for phone numbers.
+4. Select one of the phone numbers and choose **Provision**.
+5. Take note of this phone number. You will use this phone number in the **To create SMA AWS Lambda** step.
+
+#### To create SMA AWS Lambda
+
+Use the following guide to create a SMA AWS Lambda for your SMA. You provisioned phone number will invoke this SMA AWS Lambda
+when SMA receives a call from your Alexa skill.
+
+1. Open the AWS Lambda console at https://console.aws.amazon.com/lambda/home.
+2. Choose **Create function**.
+3. Leave the defaults including: **Author from scratch** and create a name for your function.
+4. Choose **Create Function**
+5. Take note of the ARN of this AWS Lambda by choosing the **Copy ARN** at the top right corner. You will use this phone number in the **To create SMA** step.
+6. Choose your newly created function. In the **Code** tab, copy the code in `apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-play-audio/index.js` into the "index.js" file. Choose **Deploy** to deploy the code.
+7. Choose **Configuration** and then **Permissions**
+8. Under **Resource-based policy statements**, choose **Add permissions**
+9. Select **AWS account**. Enter **ChimeSipMediaApplicationLambdaInvokePolicy** for Statement ID. Enter voiceconnector.chime.amazonaws.com for Principal.
+10. Select "lambda:InvokeFunction" in the **Action** drop down list. Choose **Save**
+
+#### To create SMA
+
+Use the following steps to create a SMA application and rule to instruct SMA to invoke your SMA AWS Lambda when when SMA receives a call from your Alexa skill.
+
+1. Open the Amazon Chime SDK console at https://console.aws.amazon.com/chime-sdk/home.
+2. Choose **SIP media applications**
+3. Choose the **Create**
+4. Provide a name for your SMA application. Select **US East (N. Virginia)** as AWS region. Enter the ARN of the SMA AWS Lambda that you created above.
+5. Choose **Create**.
+6. Select your newly created SMA Application. Select **Rules** and choose **Create**
+7. Provide a name for your SMA application rule. Select **To phone number** as the Trigger type.
+8. Select the phone number that you just provisioned above in the **Phone number** drop down. Choose **Next** to create the SMA application rule.
+9. You have successfully created a SMA application. You can call the phone number that you just provisioned to verify that your SMA AWS Lambda is invoked.
+
+### Enable Amazon Chime SDK Alexa Skill calling
+
+#### To find the Skill's client ID
+
+To integrate your Alexa Skill with an Amazon Chime SDK SIP media application, you first need to find the Skill's client ID.
+
+Note: Alexa Skills have skill IDs and client IDs. For these steps, you only use the client ID.
+
+To find a Skill's client ID
+
+1. In the Alexa Developer Console, choose the desired Skill.
+2. Choose Tools and then Permission.
+3. At the bottom of the page, choose Timers to enable the Timers permission, and then choose Timers to disable the Timers permission.
+   The client ID appears at the bottom of the Permission page. The ID has a prefix of amzn1.application-oa2-client followed by a string of characters.
+   For example, amzn1.application-oa2-client.ad213256-e602-4756-9534-cc3b76b670b4.
+4. Copy that ID and go to the next steps.
+
+#### Integrate the Skill with a SIP media application
+
+1. Open the Amazon Chime SDK console at https://console.aws.amazon.com/chime-sdk/home.
+2. In the navigation pane, under SIP trunking, choose SIP media applications.
+3. Select the SIP media application that you want to integrate.
+4. Choose the **Alexa Skill Configuration** tab.
+5. Under **Alexa Skill Status**, choose **Enabled**.
+6. Under **Alexa Skill Client ID**, enter the ID from the previous steps.
+7. Choose Save.
+
+#### Enable the Communication - Calling permission for the Skill
+
+After you integrate your Skill with a SIP media application, you use the Alexa Developer Console to
+enable the "Communication - Calling" permission for the Skill. By default, that permission only appears after you integrate
+a Skill with a SIP media application. Once you do that, the Communication - Calling permission appears at the bottom
+of the Permission page in the Alexa Developer Console.
+
+After you enable the permission, the Skill prompts users for their consent to make a call.
+
+To enable the permission
+
+1. In the [Alexa Developer Console](https://developer.amazon.com/alexa/console/ask), choose the desired Skill.
+2. Choose Tools and then Permission.
+3. At the bottom of the page, move the Communication - Calling slider to the on position.
+
+## Use sample customer service Alexa Skill
+
+Once you enabled Alexa skill calling for your accounts, you can enable Alexa skill calling for your devices.
+Your users uses the following steps to enable your Alexa skill and use your skill to place a call.
+
+#### Enable Alexa skill for your Alexa enabled device
+
+To enable Alexa skill for your Alexa enabled device
+
+1. Login to Alexa Mobile App the same account as your Alexa Developer account. This allows you use your skill without publishing the skill.
+2. After logging on the account, choose **More**, then **Skills & Games**, then **Your Skills**, and **Dev**
+3. Find and choose the skill that you newly created. If your skill is already enabled, disable the skill and enable the skill again to accept the **Make and Receive Calls** consent.
+4. Choose **Enable**
+5. Check **Make and Receive Calls** Account Permissions
+6. Choose on **Save Permissions**.
+
+#### Use your Alexa skill to place a call with your Alexa enabled device
+
+You can invoke your skill Intent by first opening your Alexa skill and then speak the name of your Intent.
+
+1. You: "Alexa, open customer service"
+2. Alexa: "Welcome to demo customer support. You can say call customer support to reach our customer support team"
+3. You: "Alexa, call customer support"
+4. Alexa: "Calling from skill"
+5. Demo Call Center: "Thank you for calling demo customer support. Our customer representative is currently not available.
+   Please call us back during our regular business hours. Goodbye."
+
+Alternatively, you can invoke your skill Intent by speak a single sentence.
+
+1. You: "Alexa, ask customer service to call customer support"
+2. Alexa: "Calling from skill"
+3. Demo Call Center: "Thank you for calling demo customer support. Our customer representative is currently not available.
+   Please call us back during our regular business hours. Goodbye."

--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/interactionModels/custom/en-US.json
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/interactionModels/custom/en-US.json
@@ -1,0 +1,41 @@
+{
+  "interactionModel": {
+    "languageModel": {
+      "invocationName": "customer support",
+      "intents": [
+        {
+          "name": "AMAZON.CancelIntent",
+          "samples": []
+        },
+        {
+          "name": "AMAZON.HelpIntent",
+          "samples": []
+        },
+        {
+          "name": "AMAZON.StopIntent",
+          "samples": []
+        },
+        {
+          "name": "AMAZON.NavigateHomeIntent",
+          "samples": []
+        },
+        {
+          "name": "AMAZON.FallbackIntent",
+          "samples": []
+        },
+        {
+          "name": "CallSupportIntent",
+          "slots": [],
+          "samples": [
+            "agent",
+            "call customer",
+            "call support",
+            "call customer support"
+          ]
+        }
+      ],
+      "types": []
+    }
+  },
+  "version": "11"
+}

--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/config.js
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/config.js
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+const skillConfig = {
+  destinationPhoneNumber: 'placeholder',
+  sourcePhoneNumber: 'placeholder',
+};
+
+module.exports = {
+  skillConfig,
+};

--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/index.js
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/index.js
@@ -1,0 +1,223 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+const Alexa = require('ask-sdk-core');
+const axios = require('axios');
+const { v4: uuid } = require('uuid');
+const config = require('./config.js');
+
+const LaunchRequestHandler = {
+  canHandle(handlerInput) {
+    return (Alexa.getRequestType(handlerInput.requestEnvelope) === 'LaunchRequest');
+  },
+  handle(handlerInput) {
+    const speakOutput =
+      'Welcome to demo customer support. You can say call customer support to reach our customer support team. How can I help you?';
+
+    return handlerInput.responseBuilder
+      .speak(speakOutput)
+      .reprompt(speakOutput)
+      .getResponse();
+  },
+};
+
+const CallSupportIntentHandler = {
+  canHandle(handlerInput) {
+    return (
+      Alexa.getRequestType(handlerInput.requestEnvelope) === 'IntentRequest' &&
+      Alexa.getIntentName(handlerInput.requestEnvelope) === 'CallSupportIntent'
+    );
+  },
+  async handle(handlerInput) {
+    const apiAccessToken = handlerInput.requestEnvelope.context.System.apiAccessToken;
+    const endpointId = handlerInput.requestEnvelope.context.System.device.deviceId;
+
+    let speakOutput;
+    try {
+      await startCommunicationSession(
+        apiAccessToken,
+        endpointId,
+        config.skillConfig.sourcePhoneNumber,
+        config.skillConfig.destinationPhoneNumber
+      );
+      speakOutput = 'Calling from skill';
+    } catch (error) {
+      speakOutput = 'Sorry, I am having problem right now.';
+    }
+
+    return handlerInput.responseBuilder.speak(speakOutput).getResponse();
+  },
+};
+
+async function startCommunicationSession(
+  apiAccessToken,
+  endpointId,
+  sourcePhoneNumber,
+  destinationPhoneNumber
+) {
+  const request = {
+    participants: [
+      {
+        id: {
+          type: 'PHONE_NUMBER',
+          value: `${sourcePhoneNumber}`,
+        },
+        endpointId: `${endpointId}`,
+        isOriginator: true,
+      },
+      {
+        id: {
+          type: 'PHONE_NUMBER',
+          value: `${destinationPhoneNumber}`,
+        },
+        communicationProviderId: 'amzn1.alexa.csp.id.82bb98bc-384a-11ed-a261-0242ac120002',
+      },
+    ],
+    clientContext: {
+      clientSessionId: uuid(),
+    },
+  };
+
+  try {
+    const response = await axios.post(
+      'https://api.amazonalexa.com/v1/communications/session',
+      JSON.stringify(request),
+      {
+        headers: {
+          Authorization: `Bearer ${apiAccessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    console.log(`Successfully started a call. ResponseCode: ${response.status}, ResponseData: ${JSON.stringify(response.data)}`);
+  } catch (error) {
+    console.error(`Failed to start a call. ResponseCode: ${error.response.status}, ResponseData: ${JSON.stringify(error.response.data)}`);
+    throw error;
+  }
+}
+
+const HelpIntentHandler = {
+  canHandle(handlerInput) {
+    return (
+      Alexa.getRequestType(handlerInput.requestEnvelope) === 'IntentRequest' &&
+      Alexa.getIntentName(handlerInput.requestEnvelope) === 'AMAZON.HelpIntent'
+    );
+  },
+  handle(handlerInput) {
+    const speakOutput = 'You can say hello to me! How can I help?';
+
+    return handlerInput.responseBuilder
+      .speak(speakOutput)
+      .reprompt(speakOutput)
+      .getResponse();
+  },
+};
+
+const CancelAndStopIntentHandler = {
+  canHandle(handlerInput) {
+    return (
+      Alexa.getRequestType(handlerInput.requestEnvelope) === 'IntentRequest' &&
+      (Alexa.getIntentName(handlerInput.requestEnvelope) === 'AMAZON.CancelIntent' ||
+        Alexa.getIntentName(handlerInput.requestEnvelope) === 'AMAZON.StopIntent')
+    );
+  },
+  handle(handlerInput) {
+    const speakOutput = 'Goodbye!';
+
+    return handlerInput.responseBuilder.speak(speakOutput).getResponse();
+  },
+};
+/* *
+ * FallbackIntent triggers when a customer says something that doesn’t map to any intents in your skill
+ * It must also be defined in the language model (if the locale supports it)
+ * This handler can be safely added but will be ingnored in locales that do not support it yet
+ * */
+const FallbackIntentHandler = {
+  canHandle(handlerInput) {
+    return (
+      Alexa.getRequestType(handlerInput.requestEnvelope) === 'IntentRequest' &&
+      Alexa.getIntentName(handlerInput.requestEnvelope) === 'AMAZON.FallbackIntent'
+    );
+  },
+  handle(handlerInput) {
+    const speakOutput = 'Sorry, I don\'t know about that. Please try again.';
+
+    return handlerInput.responseBuilder
+      .speak(speakOutput)
+      .reprompt(speakOutput)
+      .getResponse();
+  },
+};
+/* *
+ * SessionEndedRequest notifies that a session was ended. This handler will be triggered when a currently open
+ * session is closed for one of the following reasons: 1) The user says "exit" or "quit". 2) The user does not
+ * respond or says something that does not match an intent defined in your voice model. 3) An error occurs
+ * */
+const SessionEndedRequestHandler = {
+  canHandle(handlerInput) {
+    return (Alexa.getRequestType(handlerInput.requestEnvelope) === 'SessionEndedRequest');
+  },
+  handle(handlerInput) {
+    console.log(`~~~~ Session ended: ${JSON.stringify(handlerInput.requestEnvelope)}`);
+    // Any cleanup logic goes here.
+    return handlerInput.responseBuilder.getResponse(); // notice we send an empty response
+  },
+};
+/* *
+ * The intent reflector is used for interaction model testing and debugging.
+ * It will simply repeat the intent the user said. You can create custom handlers for your intents
+ * by defining them above, then also adding them to the request handler chain below
+ * */
+const IntentReflectorHandler = {
+  canHandle(handlerInput) {
+    return (Alexa.getRequestType(handlerInput.requestEnvelope) === 'IntentRequest');
+  },
+  handle(handlerInput) {
+    const intentName = Alexa.getIntentName(handlerInput.requestEnvelope);
+    const speakOutput = `You just triggered ${intentName}`;
+
+    return (
+      handlerInput.responseBuilder
+        .speak(speakOutput)
+        //.reprompt('add a reprompt if you want to keep the session open for the user to respond')
+        .getResponse()
+    );
+  },
+};
+/**
+ * Generic error handling to capture any syntax or routing errors. If you receive an error
+ * stating the request handler chain is not found, you have not implemented a handler for
+ * the intent being invoked or included it in the skill builder below
+ * */
+const ErrorHandler = {
+  canHandle() {
+    return true;
+  },
+  handle(handlerInput, error) {
+    const speakOutput = 'Sorry, I had trouble doing what you asked. Please try again.';
+    console.log(`~~~~ Error handled: ${JSON.stringify(error)}`);
+
+    return handlerInput.responseBuilder
+      .speak(speakOutput)
+      .reprompt(speakOutput)
+      .getResponse();
+  },
+};
+
+/**
+ * This handler acts as the entry point for your skill, routing all request and response
+ * payloads to the handlers above. Make sure any new handlers or interceptors you've
+ * defined are included below. The order matters - they're processed top to bottom
+ * */
+exports.handler = Alexa.SkillBuilders.custom()
+  .addRequestHandlers(
+    LaunchRequestHandler,
+    CallSupportIntentHandler,
+    HelpIntentHandler,
+    CancelAndStopIntentHandler,
+    FallbackIntentHandler,
+    SessionEndedRequestHandler,
+    IntentReflectorHandler
+  )
+  .addErrorHandlers(ErrorHandler)
+  .withCustomUserAgent('sample/my-customer-support/v1.0')
+  .lambda();

--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/local-debugger.js
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/local-debugger.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* ## DEPRECATION NOTICE
+
+This script has been deprecated and is no longer supported. 
+Please use the [ASK Toolkit for VS Code]
+(https://marketplace.visualstudio.com/items?itemName=ask-toolkit.alexa-skills-kit-toolkit), 
+which provides a more end-to-end integration with Visual Studio Code. If you 
+use another editor/IDE, please check out the [ASK SDK Local Debug package at npm]
+(https://www.npmjs.com/package/ask-sdk-local-debug).
+
+*/
+
+const net = require('net');
+const fs = require('fs');
+
+const localDebugger = net.createServer();
+
+const httpHeaderDelimeter = '\r\n';
+const httpBodyDelimeter = '\r\n\r\n';
+const defaultHandlerName = 'handler';
+const host = 'localhost';
+const defaultPort = 0;
+
+/**
+ * Resolves the skill invoker class dependency from the user provided
+ * skill entry file.
+ */
+
+// eslint-disable-next-line import/no-dynamic-require
+const skillInvoker = require(getAndValidateSkillInvokerFile());
+const portNumber = getAndValidatePortNumber();
+const lambdaHandlerName = getLambdaHandlerName();
+
+/**
+ * Starts listening on the port for incoming skill requests.
+ */
+
+localDebugger.listen(portNumber, host, () => {
+  console.log(`Starting server on port: ${localDebugger.address().port}.`);
+});
+
+/**
+ * For a new incoming skill request a new socket connection is established.
+ * From the data received on the socket the request body is extracted, parsed into
+ * JSON and passed to the skill invoker's lambda handler.
+ * The response from the lambda handler is parsed as a HTTP 200 message format as specified
+ * here - https://developer.amazon.com/docs/custom-skills/request-and-response-json-reference.html#http-header-1
+ * The response is written onto the socket connection.
+ */
+
+localDebugger.on('connection', (socket) => {
+  console.log(`Connection from: ${socket.remoteAddress}:${socket.remotePort}`);
+  socket.on('data', (data) => {
+    const body = JSON.parse(data.toString().split(httpBodyDelimeter).pop());
+    console.log(`Request envelope: ${JSON.stringify(body)}`);
+    skillInvoker[lambdaHandlerName](body, null, (_invokeErr, response) => {
+      response = JSON.stringify(response);
+      console.log(`Response envelope: ${response}`);
+      socket.write(
+        `HTTP/1.1 200 OK${httpHeaderDelimeter}Content-Type: application/json;charset=UTF-8${httpHeaderDelimeter}Content-Length: ${response.length}${httpBodyDelimeter}${response}`
+      );
+    });
+  });
+});
+
+/**
+ * Validates user specified port number is in legal range [0, 65535].
+ * Defaults to 0.
+ */
+
+function getAndValidatePortNumber() {
+  const portNumberArgument = Number(getArgument('portNumber', defaultPort));
+  if (!Number.isInteger(portNumberArgument)) {
+    throw new Error(
+      `Port number has to be an integer - ${portNumberArgument}.`
+    );
+  }
+  if (portNumberArgument < 0 || portNumberArgument > 65535) {
+    throw new Error(
+      `Port out of legal range: ${portNumberArgument}. The port number should be in the range [0, 65535]`
+    );
+  }
+  if (portNumberArgument === 0) {
+    console.log(
+      'The TCP server will listen on a port that is free.' +
+        'Check logs to find out what port number is being used'
+    );
+  }
+  return portNumberArgument;
+}
+
+/**
+ * Gets the lambda handler name.
+ * Defaults to "handler".
+ */
+
+function getLambdaHandlerName() {
+  return getArgument('lambdaHandler', defaultHandlerName);
+}
+
+/**
+ * Validates that the skill entry file exists on the path specified.
+ * This is a required field.
+ */
+
+// eslint-disable-next-line consistent-return
+function getAndValidateSkillInvokerFile() {
+  const fileNameArgument = getArgument('skillEntryFile');
+  if (!fs.existsSync(fileNameArgument)) {
+    throw new Error(`File not found: ${fileNameArgument}`);
+  }
+  return fileNameArgument;
+}
+
+/**
+ * Helper function to fetch the value for a given argument
+ * @param {argumentName} argumentName name of the argument for which the value needs to be fetched
+ * @param {defaultValue} defaultValue default value of the argument that is returned if the value doesn't exist
+ */
+
+function getArgument(argumentName, defaultValue) {
+  const index = process.argv.indexOf(`--${argumentName}`);
+  if (index === -1 || typeof process.argv[index + 1] === 'undefined') {
+    if (defaultValue === undefined) {
+      throw new Error(`Required argument - ${argumentName} not provided.`);
+    } else {
+      return defaultValue;
+    }
+  }
+  return process.argv[index + 1];
+}

--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/package.json
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "hello-world",
+  "version": "1.2.0",
+  "description": "alexa utility for quickly building skills",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "MIT-0 license",
+  "dependencies": {
+    "ask-sdk-core": "^2.7.0",
+    "ask-sdk-model": "^1.19.0",
+    "aws-sdk": "^2.326.0",
+    "axios": "^0.18.1",
+    "uuid": "^8.3.1"
+  }
+}

--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/util.js
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/util.js
@@ -1,0 +1,17 @@
+const AWS = require('aws-sdk');
+
+const s3SigV4Client = new AWS.S3({
+  signatureVersion: 'v4',
+  region: process.env.S3_PERSISTENCE_REGION,
+});
+
+module.exports.getS3PreSignedUrl = function getS3PreSignedUrl(s3ObjectKey) {
+  const bucketName = process.env.S3_PERSISTENCE_BUCKET;
+  const s3PreSignedUrl = s3SigV4Client.getSignedUrl('getObject', {
+    Bucket: bucketName,
+    Key: s3ObjectKey,
+    Expires: 60 * 1, // the Expires is capped for 1 minute
+  });
+  console.log(`Util.s3PreSignedUrl: ${s3ObjectKey} URL ${s3PreSignedUrl}`);
+  return s3PreSignedUrl;
+};

--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-play-audio/index.js
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-play-audio/index.js
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+exports.handler = async (event, context, callback) => {
+  return {
+    SchemaVersion: '1.0',
+    Actions: await getActions(event),
+  };
+};
+
+const getActions = async (event) => {
+  const participantACallId = getParticipantACallId(event);
+  switch (event.InvocationEventType) {
+    case 'NEW_INBOUND_CALL':
+      return [createSpeakAction(participantACallId)];
+    case 'ACTION_SUCCESSFUL':
+      const actionData = event.ActionData;
+      if (actionData.Type === 'Speak') {
+        return [createHangupAction()];
+      }
+      return [];
+    default:
+      return [];
+  }
+};
+
+const createSpeakAction = (callerId) => {
+  return {
+    Type: 'Speak',
+    Parameters: {
+      CallId: callerId,
+      Engine: 'neural',
+      Text: 'Thank you for calling demo customer support. Our customer representative is currently not available. Please call us back during our regular business hours. Goodbye.',
+    },
+  };
+};
+
+const createHangupAction = () => ({
+  Type: 'Hangup',
+  Parameters: {
+    SipResponseCode: '480',
+  },
+});
+
+const getParticipantACallId = (event) => {
+  const participantA = event.CallDetails.Participants.find(
+    (participant) => participant.ParticipantTag === 'LEG-A'
+  );
+  return participantA.CallId;
+};


### PR DESCRIPTION
**Issue #:**

None. This is a new feature.

**Description of changes:**

Amazon Chime SDK Alexa skill calling allows enterprise customers to enable calling directly in their Amazon Alexa Skills. In this demo skill, we build an Alexa skill that allows a customer to place a call to a customer support.

**Testing**

1. How did you test these changes?

Deploy this Alexa skill using Alexa Developer Console and deploy this SMA into Amazon Chime SDK PSTN Audio. Use this Alexa skill to call into the SMA.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

This change is not part of the demo application

3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?

Tested within a Lambda in Alexa Developer Console and with SMA phone number.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.