### PR TITLE
Fix attachment bug when cancel the attachment selection

### DIFF
--- a/apps/chat/src/containers/input/Input.jsx
+++ b/apps/chat/src/containers/input/Input.jsx
@@ -162,6 +162,7 @@ const Input = ({ activeChannelArn, member, hasMembership }) => {
       className="write-link attach"
       onClick={(_event) => {
         uploadRef.current.value = null;
+        setUploadObj(uploadObjDefaults);
         uploadRef.current.click();
       }}
       icon={<Attachment width="1.5rem" height="1.5rem" />}
@@ -188,7 +189,7 @@ const Input = ({ activeChannelArn, member, hasMembership }) => {
                 height="1.5rem"
               />
               <Label style={{ margin: 'auto 0' }}>{uploadObj?.name}</Label>
-              <IconButton icon={<Remove width="1.5rem" height="1.5rem" />} />
+              <IconButton onClick={onRemoveAttachmentHandler} icon={<Remove width="1.5rem" height="1.5rem" />} type="button" />
             </div>
           ) : null}
         </form>

--- a/apps/televisit-demo/frontend/src/containers/input/Input.jsx
+++ b/apps/televisit-demo/frontend/src/containers/input/Input.jsx
@@ -134,7 +134,7 @@ const Input = ({ activeChannelArn, member, hasMembership }) => {
                 height="1.5rem"
               />
               <Label style={{ margin: 'auto 0' }}>{uploadObj?.name}</Label>
-              <IconButton icon={<Remove width="1.5rem" height="1.5rem" />} />
+              <IconButton onClick={onRemoveAttachmentHandler} icon={<Remove width="1.5rem" height="1.5rem" />} type="button" />
             </div>
           ) : null}
         </form>
@@ -142,6 +142,7 @@ const Input = ({ activeChannelArn, member, hasMembership }) => {
           className="write-link attach"
           onClick={(_event) => {
             uploadRef.current.value = null;
+            setUploadObj(uploadObjDefaults);
             uploadRef.current.click();
           }}
           icon={<Attachment width="1.5rem" height="1.5rem" />}


### PR DESCRIPTION
**Issue #:** 306

**Description of changes:** 

Fix attachment bug in chat and televisit demo app when user sends a message with attachment. The bug is, when sending a message with an attachment, after user selects the attachment, if user click on the "x" to cancel/de-select the attachment, the current bug will send the attachment instead. This code change fixes the behavior to allow user to de-select or cancel the attachment.

**Testing** 

1. How did you test these changes? 
Run the demo app locally and verified that the issue is fixed.
3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? Yes the chat demo application can be used to test it.
4. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors? Yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.