### PR TITLE
Update sample skill call announcement

### DIFF
--- a/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/index.js
+++ b/apps/alexa-skill-calling/skill-sample-simple-customer-support/simple-customer-support-skill/lambda/index.js
@@ -39,7 +39,7 @@ const CallSupportIntentHandler = {
         config.skillConfig.sourcePhoneNumber,
         config.skillConfig.destinationPhoneNumber
       );
-      speakOutput = 'Calling from skill';
+      speakOutput = '';
     } catch (error) {
       speakOutput = 'Sorry, I am having problem right now.';
     }


### PR DESCRIPTION
**Issue #:**

N/A

**Description of changes:**

Leave the output speech field blank. Alexa Skill Calling now natively announce an Alexa Skill call is starting. The native Amazon announcement will play even if the sample skill provide a sample announcement. Alexa Skill builder add to the native call announcement by providing call announcement phrase in output speech field.

**Testing**

Tested Alexa Skill with Alexa device.

1. How did you test these changes?

Tested Alexa Skill with Alexa device.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

No. This change must be tested with an Alexa device.

5. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?

Completed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.