### PR TITLE
Add `skipDeviceSelection` flag in meeting join view

### DIFF
--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -51,10 +51,18 @@
       }
     },
     "../../amazon-chime-sdk-component-library-react": {
-      "version": "0.0.1",
+      "version": "3.7.0",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mdx-js/loader": "^1.6.22",
         "@popperjs/core": "^2.2.2",
+        "fast-memoize": "^2.5.2",
+        "lodash.isequal": "^4.5.0",
+        "react-popper": "^2.2.4",
+        "throttle-debounce": "^2.3.0",
+        "uuid": "^8.0.0"
+      },
+      "devDependencies": {
+        "@mdx-js/loader": "^1.6.22",
         "@rollup/plugin-commonjs": "^13.0.0",
         "@rollup/plugin-node-resolve": "^8.0.1",
         "@storybook/addon-a11y": "6.5.8",
@@ -89,7 +97,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^3.10.0",
+        "amazon-chime-sdk-js": "^3.13.0",
         "babel-loader": "^8.1.0",
         "css-loader": "^6.7.1",
         "eslint": "^7.32.0",
@@ -98,12 +106,10 @@
         "eslint-plugin-react": "^7.26.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
-        "fast-memoize": "^2.5.2",
         "git-rev-sync": "^3.0.2",
         "jest": "^26.6.3",
         "jest-image-snapshot": "^4.4.0",
         "jest-puppeteer-docker": "^1.4.2",
-        "lodash.isequal": "^4.5.0",
         "postcss-loader": "^3.0.0",
         "postcss-preset-env": "^6.6.0",
         "prettier": "^2.4.1",
@@ -113,7 +119,6 @@
         "react-docgen-typescript-loader": "^3.7.2",
         "react-dom": "^17.0.1",
         "react-is": "^17.0.0",
-        "react-popper": "^2.2.4",
         "resize-observer-polyfill": "^1.5.1",
         "rimraf": "^2.6.3",
         "rollup": "^2.26.3",
@@ -125,13 +130,22 @@
         "styled-components": "^5.1.0",
         "styled-system": "^5.1.5",
         "themeprovider-storybook": "^1.8.0",
-        "throttle-debounce": "^2.3.0",
         "ts-jest": "^26.5.2",
         "ts-loader": "^6.0.2",
         "typescript": "^4.2.1",
-        "uuid": "^8.0.0",
         "webpack": "^5.72.0",
         "webpack-cli": "^4.9.2"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^15 || ^16 || ^18",
+        "npm": "^6 || ^7 || ^8"
+      },
+      "peerDependencies": {
+        "amazon-chime-sdk-js": "^3.13.0",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
+        "styled-components": "^5.0.0",
+        "styled-system": "^5.1.5"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -11811,7 +11825,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^3.10.0",
+        "amazon-chime-sdk-js": "^3.13.0",
         "babel-loader": "^8.1.0",
         "css-loader": "^6.7.1",
         "eslint": "^7.32.0",

--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -62,6 +62,8 @@ const MeetingForm: React.FC = () => {
     setLocalUserName,
     setRegion,
     setCpuUtilization,
+    skipDeviceSelection,
+    toggleMeetingJoinDeviceSelection,
   } = useAppState();
   const [meetingErr, setMeetingErr] = useState(false);
   const [nameErr, setNameErr] = useState(false);
@@ -117,6 +119,7 @@ const MeetingForm: React.FC = () => {
       const options: MeetingManagerJoinOptions = {
         deviceLabels: meetingMode === MeetingMode.Spectator ? DeviceLabels.None : DeviceLabels.AudioAndVideo,
         enableWebAudio: isWebAudioEnabled,
+        skipDeviceSelection,
       };
 
       await meetingManager.join(meetingSessionConfiguration, options);
@@ -182,7 +185,7 @@ const MeetingForm: React.FC = () => {
       <RegionSelection setRegion={setRegion} region={region} />
       <FormField
         field={Checkbox}
-        label="Join w/o Audio and Video"
+        label="Join w/o Audio and Video (spectator mode)"
         value=""
         checked={meetingMode === MeetingMode.Spectator}
         onChange={(): void => {
@@ -249,6 +252,14 @@ const MeetingForm: React.FC = () => {
         value=""
         checked={keepLastFrameWhenPaused}
         onChange={toggleKeepLastFrameWhenPaused}
+      />
+      <FormField
+        field={Checkbox}
+        label="Skip meeting join device selection"
+        value=""
+        checked={skipDeviceSelection}
+        onChange={toggleMeetingJoinDeviceSelection}
+        infoText="Please select the devices manually to successfully join a meeting"
       />
       <Flex container layout="fill-space-centered" style={{ marginTop: '2.5rem' }}>
         {isLoading ? <Spinner /> : <PrimaryButton label="Continue" onClick={handleJoinMeeting} />}

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -40,6 +40,8 @@ interface AppStateValue {
   setLocalUserName: React.Dispatch<React.SetStateAction<string>>;
   setRegion: React.Dispatch<React.SetStateAction<string>>;
   setBlob: (imageBlob: Blob) => void;
+  skipDeviceSelection: boolean;
+  toggleMeetingJoinDeviceSelection: () => void;
 }
 
 const AppStateContext = React.createContext<AppStateValue | null>(null);
@@ -76,6 +78,7 @@ export function AppStateProvider({ children }: Props) {
   });
   const [videoTransformCpuUtilization, setCpuPercentage] = useState(VideoFiltersCpuUtilization.CPU40Percent);
   const [imageBlob, setImageBlob] = useState<Blob | undefined>(undefined);
+  const [skipDeviceSelection, setSkipDeviceSelection] = useState(false);
 
   useEffect(() => {
     /* Load a canvas that will be used as the replacement image for Background Replacement */
@@ -109,6 +112,10 @@ export function AppStateProvider({ children }: Props) {
       setTheme('light');
       localStorage.setItem('theme', 'light');
     }
+  };
+
+  const toggleMeetingJoinDeviceSelection = (): void => {
+    setSkipDeviceSelection((current) => !current);
   };
 
   const toggleWebAudio = (): void => {
@@ -172,6 +179,8 @@ export function AppStateProvider({ children }: Props) {
     setLocalUserName,
     setRegion,
     setBlob,
+    skipDeviceSelection,
+    toggleMeetingJoinDeviceSelection,
   };
 
   return <AppStateContext.Provider value={providerValue}>{children}</AppStateContext.Provider>;


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

When one use `skipDeviceSelection` while joining a meeting, then, the user will have to manually select the devices either in device setup view or in meeting view screen.

**Testing**

1. How did you test these changes?

- Load the meeting demo
- Put in meeting and attendee details
- Check "Skip device selection" option
- Verify that the "Device setup" view shows next.
- Select or change the devices manually to select the audio and video devices and then join the meeting.
- Verify in meeting the attendee is seen in roster and can start video and sees it, also the mic indicator is active when talked.
- Do the same steps without checking "Skip default meeting join device listing and selection" option to make sure both enabling/disabling "Skip default meeting join device listing and selection" option works.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? apps/meeting demo

3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
Yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.