### PR TITLE
Upgrade NodeJS from 12 to 14 to fix Cloudformation deployment failure

### DIFF
--- a/apps/chat/src/backend/serverless/channelFlowBlogTemplate.yaml
+++ b/apps/chat/src/backend/serverless/channelFlowBlogTemplate.yaml
@@ -12,7 +12,7 @@ Resources:
     Description: The AWS SDK with support for Amazon Chime SDK messaging features.
     Properties:
       CompatibleRuntimes:
-        - "nodejs12.x"
+        - "nodejs14.x"
       Content:
         S3Bucket: aws-sdk-chime-channelflowdemo-assets
         S3Key: aws-sdk-chime-layer.zip
@@ -32,7 +32,7 @@ Resources:
           S3Key: ChannelFlowProfanityDLPProcessor.zip
       MemorySize: 128
       Role: !GetAtt ProcessorLambdaRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs14.x"
       Timeout: 30
       Layers:
           - !Ref AWSSDKChimeLayer
@@ -101,7 +101,7 @@ Resources:
           Variables:
               PROCESSOR_LAMBDA_ARN: !GetAtt ProfanityAndDLPProcessor.Arn
         Role: !GetAtt LambdaExecuteRole.Arn
-        Runtime: "nodejs12.x"
+        Runtime: "nodejs14.x"
         Timeout: 60
         Layers:
           - !Ref AWSSDKChimeLayer
@@ -274,7 +274,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${DemoName}-SignInHook
       Handler: "index.handler"
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       MemorySize: 512
       Role: !GetAtt LambdaExecuteRole.Arn
       Layers:

--- a/apps/chat/src/backend/serverless/channelFlowBlogTemplate.yaml
+++ b/apps/chat/src/backend/serverless/channelFlowBlogTemplate.yaml
@@ -12,7 +12,7 @@ Resources:
     Description: The AWS SDK with support for Amazon Chime SDK messaging features.
     Properties:
       CompatibleRuntimes:
-        - "nodejs14.x"
+        - "nodejs16.x"
       Content:
         S3Bucket: aws-sdk-chime-channelflowdemo-assets
         S3Key: aws-sdk-chime-layer.zip
@@ -32,7 +32,7 @@ Resources:
           S3Key: ChannelFlowProfanityDLPProcessor.zip
       MemorySize: 128
       Role: !GetAtt ProcessorLambdaRole.Arn
-      Runtime: "nodejs14.x"
+      Runtime: "nodejs16.x"
       Timeout: 30
       Layers:
           - !Ref AWSSDKChimeLayer
@@ -101,7 +101,7 @@ Resources:
           Variables:
               PROCESSOR_LAMBDA_ARN: !GetAtt ProfanityAndDLPProcessor.Arn
         Role: !GetAtt LambdaExecuteRole.Arn
-        Runtime: "nodejs14.x"
+        Runtime: "nodejs16.x"
         Timeout: 60
         Layers:
           - !Ref AWSSDKChimeLayer
@@ -274,7 +274,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${DemoName}-SignInHook
       Handler: "index.handler"
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       MemorySize: 512
       Role: !GetAtt LambdaExecuteRole.Arn
       Layers:

--- a/apps/chat/src/backend/serverless/template.yaml
+++ b/apps/chat/src/backend/serverless/template.yaml
@@ -40,7 +40,7 @@ Resources:
     Description: The AWS SDK with support for Amazon Chime SDK messaging features.
     Properties:
       CompatibleRuntimes:
-        - nodejs14.x
+        - nodejs16.x
       Content:
         S3Bucket: aws-blog-business-productivity-chime-sdk
         S3Key: chat-sdk-demo/aws-sdk-chime-layer.zip
@@ -60,7 +60,7 @@ Resources:
           S3Key: ChannelFlowProfanityDLPProcessor.zip
       MemorySize: 128
       Role: !GetAtt ProcessorLambdaRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Timeout: 30
       Layers:
         - !Ref AWSSDKChimeLayer
@@ -82,7 +82,7 @@ Resources:
           S3Key: presence-demo-assets/custom-presence-channel-processor.zip
       MemorySize: 128
       Role: !GetAtt PresenceProcessorLambdaRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Timeout: 30
       Layers:
         - !Ref AWSSDKChimeLayer
@@ -185,7 +185,7 @@ Resources:
           PROCESSOR_LAMBDA_ARN: !GetAtt ProfanityAndDLPProcessor.Arn
           PRESENCE_PROCESSOR_LAMBDA_ARN: !GetAtt PresenceProcessor.Arn
       Role: !GetAtt LambdaExecuteRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Timeout: 60
       Layers:
         - !Ref AWSSDKChimeLayer
@@ -298,7 +298,7 @@ Resources:
     Properties:
       Handler: "index.handler"
       Role: !GetAtt LambdaExecuteRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Timeout: 60
       Layers:
         - !Ref AWSSDKChimeLayer
@@ -450,7 +450,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${DemoName}-SignInHook
       Handler: "index.handler"
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       MemorySize: 512
       Role: !GetAtt LambdaExecuteRole.Arn
       Layers:
@@ -927,7 +927,7 @@ Resources:
         Fn::GetAtt:
           - LambdaExecuteRole
           - Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Timeout: 60
 
   PreflightRequestLambdaPermission:
@@ -1057,7 +1057,7 @@ Resources:
           AnonUserRole: !GetAtt AuthLambdaAnonUserRole.Arn
       Layers:
         - !Ref AWSSDKChimeLayer
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Handler: index.handler
       InlineCode: |
         // Lambda that validates user tokens and returns AWS Creds for access to chime, scoped to that user
@@ -1187,7 +1187,7 @@ Resources:
       Environment:
         Variables:
           ChimeAppInstanceArn: !GetAtt TriggerChimeAppInstanceLambda.AppInstanceArn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -1308,7 +1308,7 @@ Resources:
       Environment:
         Variables:
           ChimeAppInstanceArn: !GetAtt TriggerChimeAppInstanceLambda.AppInstanceArn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -1423,7 +1423,7 @@ Resources:
       Environment:
         Variables:
           ChimeAppInstanceArn: !GetAtt TriggerChimeAppInstanceLambda.AppInstanceArn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/apps/moderated-chat-and-sentiment-analysis/backend/template.yaml
+++ b/apps/moderated-chat-and-sentiment-analysis/backend/template.yaml
@@ -56,7 +56,7 @@ Resources:
                 }
 
 
-    AWSServiceRoleForAmazonChimeSdk:
+    AWSServiceRoleForAmazonChime:
         Type: "AWS::IAM::ServiceLinkedRole"
         Properties:
           AWSServiceName: "chime.amazonaws.com"

--- a/apps/moderated-chat-and-sentiment-analysis/backend/template.yaml
+++ b/apps/moderated-chat-and-sentiment-analysis/backend/template.yaml
@@ -56,7 +56,7 @@ Resources:
                 }
 
 
-    AWSServiceRoleForAmazonChime:
+    AWSServiceRoleForAmazonChimeSdk:
         Type: "AWS::IAM::ServiceLinkedRole"
         Properties:
           AWSServiceName: "chime.amazonaws.com"
@@ -292,7 +292,7 @@ Resources:
         Description: The AWS SDK with support for Amazon Chime SDK messaging features.
         Properties:
             CompatibleRuntimes:
-            - "nodejs12.x"
+            - "nodejs16.x"
             Content:
                 S3Bucket: aws-sdk-chime-moderatedchatdemo-assets
                 S3Key: AWSSDKChimeLayer.zip
@@ -312,7 +312,7 @@ Resources:
                 S3Key: AWSSDKChimeModeratedChatDemo-MessageModerator.zip
             MemorySize: 128
             Role: !GetAtt LambdaKinesisRole.Arn
-            Runtime: "nodejs12.x"
+            Runtime: "nodejs16.x"
             Timeout: 30
             TracingConfig:
                 Mode: "PassThrough"
@@ -333,7 +333,7 @@ Resources:
                 S3Key: AWSSDKChimeModeratedChatDemo-createChatUser.zip
             MemorySize: 128
             Role: !GetAtt AuthLambdaIAMRole.Arn
-            Runtime: "nodejs12.x"
+            Runtime: "nodejs16.x"
             Timeout: 3
             TracingConfig:
                 Mode: "PassThrough"
@@ -348,7 +348,7 @@ Resources:
             Handler: "index.handler"
             MemorySize: 128
             Role: !GetAtt LambdaExecuteRole.Arn
-            Runtime: "nodejs12.x"
+            Runtime: "nodejs16.x"
             Timeout: 900
             TracingConfig:
                 Mode: "PassThrough"

--- a/apps/real-time-collaboration/backend/template.yaml
+++ b/apps/real-time-collaboration/backend/template.yaml
@@ -145,7 +145,7 @@ Resources:
     Description: The AWS SDK with support for Amazon Chime SDK messaging features.
     Properties:
       CompatibleRuntimes:
-        - "nodejs12.x"
+        - "nodejs16.x"
       Content:
         S3Bucket: aws-sdk-chime-real-time-collaboration-assets
         S3Key: AWSSDKChimeLayer.zip
@@ -166,7 +166,7 @@ Resources:
         S3Key: AWSSDKChimeCollabAppDemo-CreateUser.zip
       MemorySize: 128
       Role: !GetAtt CollabLambdaIAMRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs16.x"
       Timeout: 3
       TracingConfig:
         Mode: "PassThrough"
@@ -191,7 +191,7 @@ Resources:
         S3Key: AWSSDKChimeCollabAppDemo-CreateChannel.zip
       MemorySize: 128
       Role: !GetAtt CollabLambdaIAMRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs16.x"
       Timeout: 3
       TracingConfig:
         Mode: "PassThrough"
@@ -211,7 +211,7 @@ Resources:
       Handler: "index.handler"
       MemorySize: 128
       Role: !GetAtt LambdaExecuteRole.Arn
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs16.x"
       Timeout: 900
       TracingConfig:
         Mode: "PassThrough"


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Upgrade NodeJS from 12 to 14 to fix Cloudformation deployment failure

**Testing**

1. How did you test these changes? For chat demo with main template and channel flow template, as well as the real time collaboration demo and post processing demo, I deployed the new template to Cloudformation and deployment succeeded. Used the output from the deployment and started the local server, everything works as expected, such as user sign up, log in, createChannel and enable channel flow, then send messages.
3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it? The chat demo applications,
4. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors? Yes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.