### PR TITLE
Switch the amazon chime endpoint due to ending support

### DIFF
--- a/apps/meeting/server.js
+++ b/apps/meeting/server.js
@@ -30,7 +30,7 @@ if (alternateEndpoint) {
   chime.endpoint = new AWS.Endpoint(alternateEndpoint);
 } else {
   chime.endpoint = new AWS.Endpoint(
-    'https://service.chime.aws.amazon.com/console'
+    'https://meetings-chime.us-east-1.amazonaws.com'
   );
 }
 


### PR DESCRIPTION
**Issue #2697: This is an open issue in the [amazon-chime-sdk-js](https://github.com/aws/amazon-chime-sdk-js) GitHub repository**

**Description of changes:**
The React demo application was failing for me with the following error:
> Account Id xxxxxxxxxxxx is not authorized to call deprecated Amazon Chime SDK API on the "chime" endpoint, use one of the "*-chime*" endpoints instead.
After some searching, I came across [issue #2697: [Action may be required] Amazon Chime SDK APIs in the Chime namespace are no longer supported for new customers](https://github.com/aws/amazon-chime-sdk-js/issues/2697).

As mentioned in the issue, I updated the endpoint for chime from `https://service.chime.aws.amazon.com/console` to `https://meetings-chime.us-east-1.amazonaws.com/`. This resolved the error for me.

**Testing**

1. **How did you test these changes?** I tested by running the demo application which worked successfully.
2. **Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?** I ran the React demo application which can be found in [apps/meeting](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting) folder.
3. **If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?** Yes, the project build was successful without any warnings and errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.