### PR TITLE
Fix error useBackgroundReplacement not in BackgroundReplacementProvider

### DIFF
--- a/apps/meeting/src/components/DeviceSelection/CameraDevices/BackgroundReplacementDropdown.tsx
+++ b/apps/meeting/src/components/DeviceSelection/CameraDevices/BackgroundReplacementDropdown.tsx
@@ -22,7 +22,7 @@ export const BackgroundReplacementDropdown: React.FC<Props> = ({
 }) => {
   const { selectedDevice } = useVideoInputs();
   const { backgroundReplacementOption, setBackgroundReplacementOption, replacementOptionsList } = useAppState();
-  const { changeBackgroundReplacementImage } = useBackgroundReplacement();
+  const { isBackgroundReplacementSupported, changeBackgroundReplacementImage } = useBackgroundReplacement();
   const [isLoading, setIsLoading] = useState(false);
   const logger = useLogger();
 
@@ -53,13 +53,17 @@ export const BackgroundReplacementDropdown: React.FC<Props> = ({
   };
 
   return (
-    <FormField
-      field={Select}
-      options={replacementOptionsList}
-      onChange={selectReplacement}
-      value={backgroundReplacementOption}
-      label={label}
-    />
+    <>
+    {isBackgroundReplacementSupported ? (
+      <FormField
+        field={Select}
+        options={replacementOptionsList}
+        onChange={selectReplacement}
+        value={backgroundReplacementOption}
+        label={label}
+      />
+    ) : ''}
+  </>
   );
 };
 

--- a/apps/meeting/src/components/DeviceSelection/CameraDevices/index.tsx
+++ b/apps/meeting/src/components/DeviceSelection/CameraDevices/index.tsx
@@ -20,7 +20,6 @@ import { BackgroundReplacementDropdown } from '../CameraDevices/BackgroundReplac
 const CameraDevices = () => {
   const { videoTransformCpuUtilization } = useAppState();
   const videoTransformsEnabled = videoTransformCpuUtilization !== VideoFiltersCpuUtilization.Disabled;
-  const { isBackgroundReplacementSupported } = useBackgroundReplacement();
   return (
     <div>
       <Heading tag="h2" level={6} css={title}>
@@ -37,7 +36,7 @@ const CameraDevices = () => {
           <VideoTransformDropdown />
         </StyledInputGroup> : ''
       }
-      { isBackgroundReplacementSupported ?
+      { videoTransformsEnabled ?
         <StyledInputGroup>
           <BackgroundReplacementDropdown />
         </StyledInputGroup> : ''


### PR DESCRIPTION
**Issue #:**
https://sim.amazon.com/issues/WTBugs-30848
**Description of changes:**
Move the usage of useBackgroundReplacement into BackgroundReplacementProvider
**Testing**

1. How did you test these changes?
Test with demo app
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Yes, apps/meeting
3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
Yes
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.