### PR TITLE
Bump submodule version to latest

### DIFF
--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -155,7 +155,7 @@
       }
     },
     "../../amazon-chime-sdk-component-library-react": {
-      "version": "3.9.0",
+      "version": "3.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@popperjs/core": "^2.2.2",
@@ -202,7 +202,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^3.21.1",
+        "amazon-chime-sdk-js": "^3.23.0",
         "babel-loader": "^8.1.0",
         "css-loader": "^6.7.1",
         "eslint": "^7.32.0",
@@ -247,7 +247,7 @@
         "npm": "^8 || ^9 || ^10"
       },
       "peerDependencies": {
-        "amazon-chime-sdk-js": "^3.21.1",
+        "amazon-chime-sdk-js": "^3.23.0",
         "react": "^17.0.1 || ^18.0.0",
         "react-dom": "^17.0.1 || ^18.0.0",
         "styled-components": "^5.0.0",
@@ -12496,7 +12496,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^3.21.1",
+        "amazon-chime-sdk-js": "^3.23.0",
         "babel-loader": "^8.1.0",
         "css-loader": "^6.7.1",
         "eslint": "^7.32.0",


### PR DESCRIPTION
**Issue #:**
The current React SDK version used in meeting demo does not contain the new APIs for replacement.

**Description of changes:**
Bump submodule version to latest.

**Testing**

1. How did you test these changes?

Run the demo and verified locally.

3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?

Meeting demo. E2e test and verify `background replacement - beach` option is working fine.

5. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
Yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.