### PR TITLE
Pass logger to bgBlur, bgReplacement processors

### DIFF
--- a/apps/meeting/src/containers/MeetingProviderWrapper/index.tsx
+++ b/apps/meeting/src/containers/MeetingProviderWrapper/index.tsx
@@ -8,6 +8,7 @@ import {
   BackgroundBlurProvider,
   BackgroundReplacementProvider,
   MeetingProvider,
+  useLogger,
   useVoiceFocus,
   VoiceFocusProvider,
 } from 'amazon-chime-sdk-component-library-react';
@@ -42,6 +43,7 @@ const MeetingProviderWithDeviceReplacement: React.FC<PropsWithChildren> = ({ chi
 
 const MeetingProviderWrapper: React.FC = () => {
   const { isWebAudioEnabled, videoTransformCpuUtilization, imageBlob, joinInfo } = useAppState();
+  const logger = useLogger();
 
   const isFilterEnabled = videoTransformCpuUtilization !== VideoFiltersCpuUtilization.Disabled;
 
@@ -108,8 +110,8 @@ const MeetingProviderWrapper: React.FC = () => {
     }
     console.log(`Using ${filterCPUUtilization} background blur and replacement`);
     return (
-      <BackgroundBlurProvider options={{ filterCPUUtilization }}>
-        <BackgroundReplacementProvider options={{ imageBlob, filterCPUUtilization }}>
+      <BackgroundBlurProvider options={{ filterCPUUtilization, logger }}>
+        <BackgroundReplacementProvider options={{ imageBlob, filterCPUUtilization, logger }}>
           {children}
         </BackgroundReplacementProvider>
       </BackgroundBlurProvider>


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Pass logger to bgBlur, bgReplacement processors so the logging behavior is consistent with rest of components

**Testing**

1. How did you test these changes? Setting log level to off, verify the log doesn't show on console.
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.