### PR TITLE
Update JS SDK version in meeting demo to match submodule

### DIFF
--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-chime-sdk-meetings": "^3.490.0",
         "amazon-chime-sdk-component-library-react": "file:../../amazon-chime-sdk-component-library-react",
-        "amazon-chime-sdk-js": "^3.21.1",
+        "amazon-chime-sdk-js": "^3.23.0",
         "body-parser": "^1.20.2",
         "fs-extra": "^10.1.0",
         "lodash.isequal": "^4.5.0",
@@ -3371,9 +3371,9 @@
       "link": true
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.21.1.tgz",
-      "integrity": "sha512-2LXDyCa0SMjtORp70LgIBM7N5ycLuyr0WUtouKZzOrvTfkbtfY1crlZuOTUkaDfFdNw86j/dJn0uAipuyFJJLQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.23.0.tgz",
+      "integrity": "sha512-iEQrzphamKI2gLnGIM+vqKnqhVQAVEVnDKxsPFYh/G8IkxL4PduclPGSc5RdY4OHKZy9dUrY4TMtDgXd3B6peA==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",
         "@aws-sdk/client-chime-sdk-messaging": "^3.341.0",
@@ -3381,12 +3381,12 @@
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
         "pako": "^2.0.4",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.3.0",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
       },
       "engines": {
-        "node": "^18 || ^19 || ^20",
+        "node": "^18 || ^19 || ^20 || ^22",
         "npm": "^8 || ^9 || ^10"
       }
     },
@@ -7564,9 +7564,9 @@
       "dev": true
     },
     "node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -12543,9 +12543,9 @@
       }
     },
     "amazon-chime-sdk-js": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.21.1.tgz",
-      "integrity": "sha512-2LXDyCa0SMjtORp70LgIBM7N5ycLuyr0WUtouKZzOrvTfkbtfY1crlZuOTUkaDfFdNw86j/dJn0uAipuyFJJLQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.23.0.tgz",
+      "integrity": "sha512-iEQrzphamKI2gLnGIM+vqKnqhVQAVEVnDKxsPFYh/G8IkxL4PduclPGSc5RdY4OHKZy9dUrY4TMtDgXd3B6peA==",
       "requires": {
         "@aws-crypto/sha256-js": "^2.0.1",
         "@aws-sdk/client-chime-sdk-messaging": "^3.341.0",
@@ -12553,7 +12553,7 @@
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
         "pako": "^2.0.4",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.3.0",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
       }
@@ -15660,9 +15660,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/apps/meeting/package.json
+++ b/apps/meeting/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@aws-sdk/client-chime-sdk-meetings": "^3.490.0",
     "amazon-chime-sdk-component-library-react": "file:../../amazon-chime-sdk-component-library-react",
-    "amazon-chime-sdk-js": "^3.21.1",
+    "amazon-chime-sdk-js": "^3.23.0",
     "body-parser": "^1.20.2",
     "fs-extra": "^10.1.0",
     "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
**Issue #:**
There's type error in meeting demo. Because the meeting app is using `amazon-chime-sdk-js@3.21.1`, the default submodule commit is using `v3.23.0`.

**Description of changes:**

Update JS SDK version in meeting demo to match submodule v3.23.0

**Testing**

1. How did you test these changes?
Run demo locally and verify no type error.

2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
N/A

3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.