### PR TITLE
Avoid re-render the page upon text input change

### DIFF
--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -43,7 +43,6 @@ const MeetingForm: React.FC = () => {
   const {
     region,
     meetingId,
-    localUserName,
     meetingMode,
     enableSimulcast,
     priorityBasedPolicy,
@@ -65,6 +64,8 @@ const MeetingForm: React.FC = () => {
     skipDeviceSelection,
     toggleMeetingJoinDeviceSelection,
   } = useAppState();
+  const [formMeetingId, setFormMeetingId] = useState('');
+  const [formLocalUserName, setFormLocalUserName] = useState('');
   const [meetingErr, setMeetingErr] = useState(false);
   const [nameErr, setNameErr] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -74,8 +75,11 @@ const MeetingForm: React.FC = () => {
 
   const handleJoinMeeting = async (e: React.FormEvent) => {
     e.preventDefault();
-    const id = meetingId.trim().toLocaleLowerCase();
-    const attendeeName = localUserName.trim();
+    const id = formMeetingId.trim().toLocaleLowerCase();
+    const attendeeName = formLocalUserName.trim();
+    
+    setMeetingId(id);
+    setLocalUserName(attendeeName);
 
     if (!id || !attendeeName) {
       if (!attendeeName) {
@@ -125,7 +129,7 @@ const MeetingForm: React.FC = () => {
       await meetingManager.join(meetingSessionConfiguration, options);
       if (meetingMode === MeetingMode.Spectator) {
         await meetingManager.start();
-        navigate(`${routes.MEETING}/${meetingId}`);
+        navigate(`${routes.MEETING}/${id}`);
       } else {
         setMeetingMode(MeetingMode.Attendee);
         navigate(routes.DEVICE);
@@ -150,7 +154,7 @@ const MeetingForm: React.FC = () => {
       <FormField
         field={Input}
         label="Meeting Id"
-        value={meetingId}
+        value={formMeetingId}
         infoText="Anyone with access to the meeting ID can join"
         fieldProps={{
           name: 'meetingId',
@@ -159,7 +163,7 @@ const MeetingForm: React.FC = () => {
         errorText="Please enter a valid meeting ID"
         error={meetingErr}
         onChange={(e: ChangeEvent<HTMLInputElement>): void => {
-          setMeetingId(e.target.value);
+          setFormMeetingId(e.target.value);
           if (meetingErr) {
             setMeetingErr(false);
           }
@@ -168,7 +172,7 @@ const MeetingForm: React.FC = () => {
       <FormField
         field={Input}
         label="Name"
-        value={localUserName}
+        value={formLocalUserName}
         fieldProps={{
           name: 'name',
           placeholder: 'Enter Your Name',
@@ -176,7 +180,7 @@ const MeetingForm: React.FC = () => {
         errorText="Please enter a valid name"
         error={nameErr}
         onChange={(e: ChangeEvent<HTMLInputElement>): void => {
-          setLocalUserName(e.target.value);
+          setFormLocalUserName(e.target.value);
           if (nameErr) {
             setNameErr(false);
           }


### PR DESCRIPTION
**Issue #: every key stroke will initiate a page re-render.

**Description of changes:**

**Testing**

1. How did you test these changes?
Locally and deployed to personal CF
3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
4. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.