### PR TITLE
Add multiple content shares support in meeting demo

### DIFF
--- a/apps/meeting/package-lock.json
+++ b/apps/meeting/package-lock.json
@@ -155,7 +155,7 @@
       }
     },
     "../../amazon-chime-sdk-component-library-react": {
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@popperjs/core": "^2.2.2",
@@ -179,7 +179,6 @@
         "@storybook/blocks": "^7.0.2",
         "@storybook/react": "7.0.2",
         "@storybook/react-webpack5": "^7.0.2",
-        "@storybook/storybook-deployer": "^2.8.16",
         "@storybook/testing-library": "^0.0.14-next.2",
         "@storybook/theming": "7.0.2",
         "@testing-library/dom": "^9.3.0",
@@ -201,7 +200,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^3.23.0",
+        "amazon-chime-sdk-js": "^3.27.1",
         "babel-loader": "^8.1.0",
         "css-loader": "^6.7.1",
         "eslint": "^7.32.0",
@@ -247,7 +246,7 @@
         "npm": "^8 || ^9 || ^10"
       },
       "peerDependencies": {
-        "amazon-chime-sdk-js": "^3.23.0",
+        "amazon-chime-sdk-js": "^3.27.1",
         "react": "^17.0.1 || ^18.0.0",
         "react-dom": "^17.0.1 || ^18.0.0",
         "styled-components": "^5.0.0 || ^6.0.0",
@@ -12110,7 +12109,6 @@
         "@storybook/blocks": "^7.0.2",
         "@storybook/react": "7.0.2",
         "@storybook/react-webpack5": "^7.0.2",
-        "@storybook/storybook-deployer": "^2.8.16",
         "@storybook/testing-library": "^0.0.14-next.2",
         "@storybook/theming": "7.0.2",
         "@testing-library/dom": "^9.3.0",
@@ -12132,7 +12130,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^3.23.0",
+        "amazon-chime-sdk-js": "^3.27.1",
         "babel-loader": "^8.1.0",
         "css-loader": "^6.7.1",
         "eslint": "^7.32.0",

--- a/apps/meeting/server.js
+++ b/apps/meeting/server.js
@@ -16,7 +16,7 @@ const app = express();
 app.use(compression());
 app.use(express.json());
 app.use(bodyParser.json());
-morganBody(app);
+morganBody(app, { maxBodyLength: Infinity });
 
 const chimeSDKMeetings = new ChimeSDKMeetings({ region });
 

--- a/apps/meeting/src/components/VideoTileGrid/Styled.tsx
+++ b/apps/meeting/src/components/VideoTileGrid/Styled.tsx
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from 'styled-components';
+
+export const FeaturedArea = styled.div`
+  grid-area: ft;
+`;
+
+export const ContentShareGrid = styled.div`
+  display: grid;
+  grid-template-rows: ${(props) => 'repeat(2, 1fr)'};
+  grid-template-columns: ${(props) => '1fr'};
+  gap: 4px;
+  width: 100%;
+  height: 100%;
+`;

--- a/apps/meeting/src/components/VideoTileGrid/VideoTileGrid.tsx
+++ b/apps/meeting/src/components/VideoTileGrid/VideoTileGrid.tsx
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  useFeaturedTileState,
+  useRemoteVideoTileState,
+  useContentShareState,
+  useLocalVideo,
+  VideoGrid,
+  ContentShare,
+  FeaturedRemoteVideos,
+  RemoteVideos,
+  LocalVideo,
+} from 'amazon-chime-sdk-component-library-react';
+import { BaseProps } from 'amazon-chime-sdk-component-library-react/lib/components/ui/Base';
+import React from 'react';
+import { FeaturedArea, ContentShareGrid } from './Styled';
+import { Layout } from 'amazon-chime-sdk-component-library-react/lib/components/ui/VideoGrid';
+
+const fluidStyles = `
+  height: 100%;
+  width: 100%;
+`;
+
+const staticStyles = `
+  display: flex;
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  width: 20vw;
+  max-height: 30vh;
+  height: auto;
+
+  video {
+    position: static;
+  }
+`;
+
+interface Props extends BaseProps {
+  /** A component to render when there are no remote videos present */
+  noRemoteVideoView?: React.ReactNode;
+  /** The layout of the grid. */
+  layout?: Layout;
+}
+
+export const VideoTileGrid: React.FC<React.PropsWithChildren<Props>> = ({
+  noRemoteVideoView,
+  layout = 'featured',
+  ...rest
+}) => {
+  const { tileId: featureTileId } = useFeaturedTileState();
+  const { tiles: remoteVideoTiles } = useRemoteVideoTileState();
+  const { tiles: contentShareTiles } = useContentShareState();
+  const { isVideoEnabled } = useLocalVideo();
+
+  const hasContentShare = contentShareTiles.length > 0;
+  const remoteSize = remoteVideoTiles.length + contentShareTiles.length;
+  const gridSize = remoteSize > 1 && isVideoEnabled ? remoteSize + 1 : remoteSize;
+
+  const featured = (layout === 'featured' && !!featureTileId) || hasContentShare;
+
+  return (
+    <VideoGrid {...rest} size={gridSize} layout={featured ? 'featured' : null}>
+      {contentShareTiles.length === 1 ? (
+        <ContentShare css="grid-area: ft;" tileId={contentShareTiles[0]} />
+      ) : contentShareTiles.length > 1 ? (
+        // For multiple content shares, create a grid container in featured area
+        <FeaturedArea>
+          <ContentShareGrid>
+            {contentShareTiles.map((tileId) => (
+              <ContentShare key={tileId} tileId={tileId} />
+            ))}
+          </ContentShareGrid>
+        </FeaturedArea>
+      ) : null}
+      {layout === 'featured' ? <FeaturedRemoteVideos /> : <RemoteVideos />}
+      <LocalVideo nameplate="Me" css={gridSize > 1 ? fluidStyles : staticStyles} />
+      {remoteSize === 0 && noRemoteVideoView}
+    </VideoGrid>
+  );
+};
+
+export default VideoTileGrid;

--- a/apps/meeting/src/containers/MeetingForm/index.tsx
+++ b/apps/meeting/src/containers/MeetingForm/index.tsx
@@ -52,11 +52,13 @@ const MeetingForm: React.FC = () => {
     videoTransformCpuUtilization: videoTransformCpuUtilization,
     setJoinInfo,
     isEchoReductionEnabled,
+    enableMaxContentShares,
     toggleEchoReduction,
     toggleWebAudio,
     toggleSimulcast,
     togglePriorityBasedPolicy,
     toggleKeepLastFrameWhenPaused,
+    toggleMaxContentShares,
     setMeetingMode,
     setMeetingId,
     setLocalUserName,
@@ -122,7 +124,7 @@ const MeetingForm: React.FC = () => {
         skipDeviceSelection,
       };
 
-      await meetingManager.join(meetingSessionConfiguration, options);
+      await meetingManager.join(meetingSessionConfiguration as any, options);
       if (meetingMode === MeetingMode.Spectator) {
         await meetingManager.start();
         navigate(`${routes.MEETING}/${meetingId}`);
@@ -255,11 +257,19 @@ const MeetingForm: React.FC = () => {
       />
       <FormField
         field={Checkbox}
-        label="Skip meeting join device selection"
+        label="Skip Meeting Join Device Selection"
         value=""
         checked={skipDeviceSelection}
         onChange={toggleMeetingJoinDeviceSelection}
         infoText="Please select the devices manually to successfully join a meeting"
+      />
+      <FormField
+        field={Checkbox}
+        label="Enable Multiple Content Shares (max: 2)"
+        value=""
+        checked={enableMaxContentShares}
+        onChange={toggleMaxContentShares}
+        infoText="Allow up to 2 simultaneous content shares in the meeting"
       />
       <Flex container layout="fill-space-centered" style={{ marginTop: '2.5rem' }}>
         {isLoading ? <Spinner /> : <PrimaryButton label="Continue" onClick={handleJoinMeeting} />}

--- a/apps/meeting/src/containers/MeetingProviderWrapper/index.tsx
+++ b/apps/meeting/src/containers/MeetingProviderWrapper/index.tsx
@@ -3,7 +3,7 @@
 
 import React, { PropsWithChildren } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { AudioInputDevice, Device, VoiceFocusModelName, VoiceFocusTransformDevice } from 'amazon-chime-sdk-js';
+import { AudioInputDevice, VoiceFocusModelName, VoiceFocusTransformDevice } from 'amazon-chime-sdk-js';
 import {
   BackgroundBlurProvider,
   BackgroundReplacementProvider,
@@ -12,22 +12,20 @@ import {
   useVoiceFocus,
   VoiceFocusProvider,
 } from 'amazon-chime-sdk-component-library-react';
+import { useAppState } from '../../providers/AppStateProvider';
 
 import routes from '../../constants/routes';
 import { NavigationProvider } from '../../providers/NavigationProvider';
 import NoMeetingRedirect from '../NoMeetingRedirect';
 import { Meeting, Home, DeviceSetup } from '../../views';
 import MeetingEventObserver from '../MeetingEventObserver';
-import { useAppState } from '../../providers/AppStateProvider';
 import { VideoFiltersCpuUtilization } from '../../types';
 
 const MeetingProviderWithDeviceReplacement: React.FC<PropsWithChildren> = ({ children }) => {
   const { addVoiceFocus } = useVoiceFocus();
+  const { enableMaxContentShares } = useAppState();
 
-  const onDeviceReplacement = (
-    nextDevice: string,
-    currentDevice: AudioInputDevice
-  ): Promise<Device | VoiceFocusTransformDevice> => {
+  const onDeviceReplacement = (nextDevice: string, currentDevice: AudioInputDevice) => {
     if (currentDevice instanceof VoiceFocusTransformDevice) {
       return addVoiceFocus(nextDevice);
     }
@@ -35,7 +33,8 @@ const MeetingProviderWithDeviceReplacement: React.FC<PropsWithChildren> = ({ chi
   };
 
   const meetingConfigValue = {
-    onDeviceReplacement,
+    onDeviceReplacement: onDeviceReplacement as any,
+    ...(enableMaxContentShares ? { maxContentShares: 2 } : {}),
   };
 
   return <MeetingProvider {...meetingConfigValue}>{children}</MeetingProvider>;

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -29,11 +29,13 @@ interface AppStateValue {
   joinInfo: JoinMeetingInfo | undefined;
   backgroundReplacementOption: ReplacementOptions;
   replacementOptionsList: ReplacementDropdownOptionType[];
+  enableMaxContentShares: boolean;
   toggleTheme: () => void;
   toggleWebAudio: () => void;
   toggleSimulcast: () => void;
   togglePriorityBasedPolicy: () => void;
   toggleKeepLastFrameWhenPaused: () => void;
+  toggleMaxContentShares: () => void;
   setCpuUtilization: (videoTransformCpuUtilization: string) => void;
   toggleEchoReduction: () => void;
   setMeetingMode: React.Dispatch<React.SetStateAction<MeetingMode>>;
@@ -84,6 +86,7 @@ export function AppStateProvider({ children }: Props) {
   const [imageBlob, setImageBlob] = useState<Blob | undefined>(undefined);
   const [skipDeviceSelection, setSkipDeviceSelection] = useState(false);
   const [backgroundReplacementOption, setBackgroundReplacementOption] = useState<ReplacementOptions>(ReplacementOptions.Blue);
+  const [enableMaxContentShares, setEnableMaxContentShares] = useState(false);
 
   const replacementOptionsList: ReplacementDropdownOptionType[] = [
     {
@@ -158,6 +161,10 @@ export function AppStateProvider({ children }: Props) {
     setIsEchoReductionEnabled((current) => !current);
   };
 
+  const toggleMaxContentShares = (): void => {
+    setEnableMaxContentShares((current) => !current);
+  };
+
   const providerValue = {
     meetingId,
     localUserName,
@@ -192,6 +199,8 @@ export function AppStateProvider({ children }: Props) {
     backgroundReplacementOption,
     setBackgroundReplacementOption,
     replacementOptionsList,
+    enableMaxContentShares,
+    toggleMaxContentShares,
   };
 
   return <AppStateContext.Provider value={providerValue}>{children}</AppStateContext.Provider>;

--- a/apps/meeting/src/views/Meeting/index.tsx
+++ b/apps/meeting/src/views/Meeting/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 import React from 'react';
-import { VideoTileGrid, UserActivityProvider } from 'amazon-chime-sdk-component-library-react';
+import { UserActivityProvider } from 'amazon-chime-sdk-component-library-react';
 
 import { StyledLayout, StyledContent } from './Styled';
 import NavigationControl from '../../containers/Navigation/NavigationControl';
@@ -16,6 +16,7 @@ import { VideoTileGridProvider } from '../../providers/VideoTileGridProvider';
 import { useAppState } from '../../providers/AppStateProvider';
 import { DataMessagesProvider } from '../../providers/DataMessagesProvider';
 import MeetingStatusNotifier from '../../containers/MeetingStatusNotifier';
+import VideoTileGrid from '../../components/VideoTileGrid/VideoTileGrid';
 
 const MeetingView = (props: { mode: MeetingMode }) => {
   useMeetingEndRedirect();


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- Add multiple content shares support in meeting demo
- Create a local VideoTileGrid to display 2 content share tiles
- Add a check box to meeting form to enable concurrent content shares
![image](https://github.com/user-attachments/assets/023efa8b-2ed7-4e27-87c9-2a3b0aac4a63)

**Testing**

1. How did you test these changes?
   - Tested e2e locally.
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
 yes, meeting demo
3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.