### PR TITLE
[Meeting demo] Enable WebAudio only when VF is supported and desired

### DIFF
--- a/apps/meeting/src/app.tsx
+++ b/apps/meeting/src/app.tsx
@@ -4,10 +4,12 @@
 import React, { FC, PropsWithChildren } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
+import { VoiceFocusModelName } from 'amazon-chime-sdk-js';
 import {
   NotificationProvider,
   GlobalStyles,
   LoggerProvider,
+  VoiceFocusProvider,
 } from 'amazon-chime-sdk-component-library-react';
 
 import { demoLightTheme, demoDarkTheme } from './theme/demoTheme';
@@ -21,18 +23,49 @@ const App: FC = () => (
   <Router>
     <LoggerProvider logger={meetingConfig.logger}>
       <AppStateProvider>
-        <Theme>
-          <NotificationProvider>
-            <Notifications />
-            <ErrorProvider>
-              <MeetingProviderWrapper />
-            </ErrorProvider>
-          </NotificationProvider>
-        </Theme>
+        <VoiceFocusWrapper>
+          <Theme>
+            <NotificationProvider>
+              <Notifications />
+              <ErrorProvider>
+                <MeetingProviderWrapper />
+              </ErrorProvider>
+            </NotificationProvider>
+          </Theme>
+        </VoiceFocusWrapper>
       </AppStateProvider>
     </LoggerProvider>
   </Router>
 );
+
+const VoiceFocusWrapper: React.FC<PropsWithChildren> = ({ children }) => {
+  const { joinInfo } = useAppState();
+
+  function voiceFocusName(name: string): VoiceFocusModelName {
+    if (name && ['default', 'ns_es'].includes(name)) {
+      return name as VoiceFocusModelName;
+    }
+    return 'default';
+  }
+
+  function getVoiceFocusSpecName(): VoiceFocusModelName {
+    if (joinInfo && joinInfo.Meeting?.MeetingFeatures?.Audio?.EchoReduction === 'AVAILABLE') {
+      return voiceFocusName('ns_es');
+    }
+    return voiceFocusName('default');
+  }
+
+  const vfConfigValue = {
+    spec: { name: getVoiceFocusSpecName() },
+    createMeetingResponse: joinInfo,
+  };
+
+  return (
+    <VoiceFocusProvider {...vfConfigValue}>
+      {children}
+    </VoiceFocusProvider>
+  );
+};
 
 const Theme: React.FC<PropsWithChildren> = ({ children }) => {
   const { theme } = useAppState();

--- a/apps/meeting/src/containers/DynamicMeetingControls/index.tsx
+++ b/apps/meeting/src/containers/DynamicMeetingControls/index.tsx
@@ -14,17 +14,23 @@ import {
   useDeviceLabelTriggerStatus,
   DeviceLabelTriggerStatus,
   DeviceLabels,
+  AudioInputVFControl,
 } from 'amazon-chime-sdk-component-library-react';
 
 import EndMeetingControl from '../EndMeetingControl';
 import { useNavigation } from '../../providers/NavigationProvider';
 import { StyledControls } from './Styled';
 import DevicePermissionControl from '../DevicePermissionControl/DevicePermissionControl';
+import { useAppState } from '../../providers/AppStateProvider';
+import VideoInputTransformControl from '../../components/MeetingControls/VideoInputTransformControl';
+import { VideoFiltersCpuUtilization } from '../../types';
 
 const DynamicMeetingControls = () => {
   const { toggleNavbar, closeRoster, showRoster } = useNavigation();
   const { isUserActive } = useUserActivityState();
   const status = useDeviceLabelTriggerStatus();
+  const { isVoiceFocusEnabled, videoTransformCpuUtilization } = useAppState();
+  const videoTransformsEnabled = videoTransformCpuUtilization !== VideoFiltersCpuUtilization.Disabled;
 
   const handleToggle = () => {
     if (showRoster) {
@@ -36,25 +42,18 @@ const DynamicMeetingControls = () => {
 
   return (
     <StyledControls className="controls" $active={!!isUserActive}>
-      <ControlBar
-        className="controls-menu"
-        layout="undocked-horizontal"
-        showLabels
-      >
-        <ControlBarButton
-          className="mobile-toggle"
-          icon={<Dots />}
-          onClick={handleToggle}
-          label="Menu"
-        />
-        {status === DeviceLabelTriggerStatus.GRANTED ?
+      <ControlBar className="controls-menu" layout="undocked-horizontal" showLabels>
+        <ControlBarButton className="mobile-toggle" icon={<Dots />} onClick={handleToggle} label="Menu" />
+        {status === DeviceLabelTriggerStatus.GRANTED ? (
           <>
-            <AudioInputControl />
-            <VideoInputControl />
+            {isVoiceFocusEnabled ? <AudioInputVFControl /> : <AudioInputControl />}
+            {videoTransformsEnabled ? <VideoInputTransformControl /> : <VideoInputControl />}
             <ContentShareControl />
             <AudioOutputControl />
           </>
-          : <DevicePermissionControl deviceLabels={DeviceLabels.AudioAndVideo} />}
+        ) : (
+          <DevicePermissionControl deviceLabels={DeviceLabels.AudioAndVideo} />
+        )}
 
         <EndMeetingControl />
       </ControlBar>

--- a/apps/meeting/src/containers/MeetingControls/index.tsx
+++ b/apps/meeting/src/containers/MeetingControls/index.tsx
@@ -24,7 +24,7 @@ import VideoInputTransformControl from '../../components/MeetingControls/VideoIn
 const MeetingControls: React.FC = () => {
   const { toggleNavbar, closeRoster, showRoster } = useNavigation();
   const { isUserActive } = useUserActivityState();
-  const { isWebAudioEnabled, videoTransformCpuUtilization } = useAppState();
+  const { isVoiceFocusEnabled, videoTransformCpuUtilization } = useAppState();
   const videoTransformsEnabled = videoTransformCpuUtilization !== VideoFiltersCpuUtilization.Disabled;
 
   const handleToggle = (): void => {
@@ -47,7 +47,7 @@ const MeetingControls: React.FC = () => {
           onClick={handleToggle}
           label="Menu"
         />
-        { isWebAudioEnabled ? <AudioInputVFControl /> :  <AudioInputControl /> }
+        { isVoiceFocusEnabled ? <AudioInputVFControl /> :  <AudioInputControl /> }
         { videoTransformsEnabled ? <VideoInputTransformControl /> : <VideoInputControl/> }
         <ContentShareControl />
         <AudioOutputControl />

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -3,7 +3,14 @@
 
 import React, { useContext, useState, ReactNode, useEffect } from 'react';
 import { VideoPriorityBasedPolicy } from 'amazon-chime-sdk-js';
-import { MeetingMode, Layout, VideoFiltersCpuUtilization, ReplacementOptions, ReplacementType, ReplacementDropdownOptionType } from '../types';
+import {
+  MeetingMode,
+  Layout,
+  VideoFiltersCpuUtilization,
+  ReplacementOptions,
+  ReplacementType,
+  ReplacementDropdownOptionType,
+} from '../types';
 import { JoinMeetingInfo } from '../utils/api';
 import { useLogger } from 'amazon-chime-sdk-component-library-react';
 import { createBlob } from '../utils/background-replacement';
@@ -17,7 +24,8 @@ interface AppStateValue {
   localUserName: string;
   theme: string;
   region: string;
-  isWebAudioEnabled: boolean;
+  isVoiceFocusDesired: boolean;
+  isVoiceFocusEnabled: boolean;
   videoTransformCpuUtilization: string;
   imageBlob: Blob | undefined;
   isEchoReductionEnabled: boolean;
@@ -31,7 +39,8 @@ interface AppStateValue {
   replacementOptionsList: ReplacementDropdownOptionType[];
   enableMaxContentShares: boolean;
   toggleTheme: () => void;
-  toggleWebAudio: () => void;
+  toggleVoiceFocusDesired: () => void;
+  setIsVoiceFocusEnabled: (enabled: boolean) => void;
   toggleSimulcast: () => void;
   togglePriorityBasedPolicy: () => void;
   toggleKeepLastFrameWhenPaused: () => void;
@@ -73,7 +82,8 @@ export function AppStateProvider({ children }: Props) {
   const [joinInfo, setJoinInfo] = useState<JoinMeetingInfo | undefined>(undefined);
   const [layout, setLayout] = useState(Layout.Gallery);
   const [localUserName, setLocalUserName] = useState('');
-  const [isWebAudioEnabled, setIsWebAudioEnabled] = useState(true);
+  const [isVoiceFocusDesired, setIsVoiceFocusDesired] = useState(false);
+  const [isVoiceFocusEnabled, setIsVoiceFocusEnabled] = useState(false);
   const [priorityBasedPolicy, setPriorityBasedPolicy] = useState<VideoPriorityBasedPolicy | undefined>(undefined);
   const [enableSimulcast, setEnableSimulcast] = useState(false);
   const [keepLastFrameWhenPaused, setKeepLastFrameWhenPaused] = useState(false);
@@ -85,7 +95,9 @@ export function AppStateProvider({ children }: Props) {
   const [videoTransformCpuUtilization, setCpuPercentage] = useState(VideoFiltersCpuUtilization.CPU40Percent);
   const [imageBlob, setImageBlob] = useState<Blob | undefined>(undefined);
   const [skipDeviceSelection, setSkipDeviceSelection] = useState(false);
-  const [backgroundReplacementOption, setBackgroundReplacementOption] = useState<ReplacementOptions>(ReplacementOptions.Blue);
+  const [backgroundReplacementOption, setBackgroundReplacementOption] = useState<ReplacementOptions>(
+    ReplacementOptions.Blue
+  );
   const [enableMaxContentShares, setEnableMaxContentShares] = useState(false);
 
   const replacementOptionsList: ReplacementDropdownOptionType[] = [
@@ -104,12 +116,14 @@ export function AppStateProvider({ children }: Props) {
   useEffect(() => {
     /* Load a canvas that will be used as the replacement image for Background Replacement */
     async function loadImage() {
-      const option = replacementOptionsList.find(option => backgroundReplacementOption === option.label);
+      const option = replacementOptionsList.find((option) => backgroundReplacementOption === option.label);
       if (option) {
         const blob = await createBlob(option);
         setImageBlob(blob);
       } else {
-        logger.error(`Error: Cannot find ${backgroundReplacementOption} in the replacementOptionsList: ${replacementOptionsList}`);
+        logger.error(
+          `Error: Cannot find ${backgroundReplacementOption} in the replacementOptionsList: ${replacementOptionsList}`
+        );
       }
     }
     loadImage();
@@ -129,8 +143,8 @@ export function AppStateProvider({ children }: Props) {
     setSkipDeviceSelection((current) => !current);
   };
 
-  const toggleWebAudio = (): void => {
-    setIsWebAudioEnabled((current) => !current);
+  const toggleVoiceFocusDesired = (): void => {
+    setIsVoiceFocusDesired((current) => !current);
   };
 
   const toggleSimulcast = (): void => {
@@ -169,10 +183,11 @@ export function AppStateProvider({ children }: Props) {
     meetingId,
     localUserName,
     theme,
-    isWebAudioEnabled,
     videoTransformCpuUtilization,
     imageBlob,
     isEchoReductionEnabled,
+    isVoiceFocusDesired,
+    isVoiceFocusEnabled,
     region,
     meetingMode,
     layout,
@@ -181,7 +196,8 @@ export function AppStateProvider({ children }: Props) {
     priorityBasedPolicy,
     keepLastFrameWhenPaused,
     toggleTheme,
-    toggleWebAudio,
+    toggleVoiceFocusDesired,
+    setIsVoiceFocusEnabled,
     togglePriorityBasedPolicy,
     toggleKeepLastFrameWhenPaused,
     toggleSimulcast,


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Enable WebAudio only when VF is supported and desired
- Break down `handleJoinMeeting` into modular functions  
- Optimize Voice Focus support check to only wait when needed
- Always render VoiceFocusProvider at top level in order to check VF support any time
- Wait for VoiceFocus support check to complete before joining the meeting if VF is desired
- Remove isWebAudioEnabled flag (replaced by isVFEnabled), it's now calculated based on isVFSupported and isVFDesired.

**Testing**

1. How did you test these changes?
    -  Verified locally with different combination of check box enablement.
3. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
    - Yes, meeting demo
5. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
    - Yes
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.