### PR TITLE
fix(meeting-demo): persist selected video transform from device setup into the meeting

### DIFF
--- a/apps/meeting/src/components/DeviceSelection/CameraDevices/VideoTransformDropdown.tsx
+++ b/apps/meeting/src/components/DeviceSelection/CameraDevices/VideoTransformDropdown.tsx
@@ -12,6 +12,7 @@ import {
   useMeetingManager,
 } from 'amazon-chime-sdk-component-library-react';
 import { VideoTransformOptions, VideoTransformDropdownOptionType } from '../../../types/index';
+import { useAppState } from '../../../providers/AppStateProvider';
 
 interface Props {
   /* Title for the dropdown, defaults to `Video Transform Dropdown` */
@@ -21,7 +22,9 @@ interface Props {
 export const VideoTransformDropdown: React.FC<Props> = ({
   label = 'Video Transform Dropdown',
 }) => {
-  const [transformOption, setTransformOption] = useState(VideoTransformOptions.None);
+  // The selected transform is stored in AppState so the in-meeting control can
+  // re-apply it after navigating from the device-setup page.
+  const { activeVideoTransformOption, setActiveVideoTransformOption } = useAppState();
   // Both hooks are needed because this component uses both blur and replacement filters.
   const { isBackgroundBlurSupported, createBackgroundBlurDevice } =
     useBackgroundBlur();
@@ -33,8 +36,8 @@ export const VideoTransformDropdown: React.FC<Props> = ({
 
   // useEffect to listen on selected video input device if changed by other components
   useEffect(() => {
-    if (!isVideoTransformDevice(selectedDevice) && transformOption !== VideoTransformOptions.None) {
-      setTransformOption(VideoTransformOptions.None);
+    if (!isVideoTransformDevice(selectedDevice) && activeVideoTransformOption !== VideoTransformOptions.None) {
+      setActiveVideoTransformOption(VideoTransformOptions.None);
     }
   }, [selectedDevice]);
 
@@ -79,8 +82,8 @@ export const VideoTransformDropdown: React.FC<Props> = ({
       }
       // Select the newly created device from the above logic as the video input device.
       await meetingManager.startVideoInputDevice(currentDevice);
-      // Update the current selected transform.
-      setTransformOption(selectedTransform);
+      // Update the current selected transform (shared via AppState).
+      setActiveVideoTransformOption(selectedTransform);
     } catch (e) {
       console.error('Error trying to apply', selectTransform, e);
     } finally {
@@ -93,7 +96,7 @@ export const VideoTransformDropdown: React.FC<Props> = ({
       field={Select}
       options={options}
       onChange={selectTransform}
-      value={transformOption}
+      value={activeVideoTransformOption}
       label={label}
     />
   );

--- a/apps/meeting/src/components/DeviceSelection/CameraDevices/VideoTransformDropdown.tsx
+++ b/apps/meeting/src/components/DeviceSelection/CameraDevices/VideoTransformDropdown.tsx
@@ -24,7 +24,7 @@ export const VideoTransformDropdown: React.FC<Props> = ({
 }) => {
   // The selected transform is stored in AppState so the in-meeting control can
   // re-apply it after navigating from the device-setup page.
-  const { activeVideoTransformOption, setActiveVideoTransformOption } = useAppState();
+  const { videoTransformOption, setVideoTransformOption } = useAppState();
   // Both hooks are needed because this component uses both blur and replacement filters.
   const { isBackgroundBlurSupported, createBackgroundBlurDevice } =
     useBackgroundBlur();
@@ -36,8 +36,8 @@ export const VideoTransformDropdown: React.FC<Props> = ({
 
   // useEffect to listen on selected video input device if changed by other components
   useEffect(() => {
-    if (!isVideoTransformDevice(selectedDevice) && activeVideoTransformOption !== VideoTransformOptions.None) {
-      setActiveVideoTransformOption(VideoTransformOptions.None);
+    if (!isVideoTransformDevice(selectedDevice) && videoTransformOption !== VideoTransformOptions.None) {
+      setVideoTransformOption(VideoTransformOptions.None);
     }
   }, [selectedDevice]);
 
@@ -59,7 +59,7 @@ export const VideoTransformDropdown: React.FC<Props> = ({
 
   // Creates a device based on the selections (None, Blur, Replacement) and uses it as input.
   const selectTransform = async (e: ChangeEvent<HTMLSelectElement>) => {
-    const selectedTransform = e.target.value;
+    const selectedTransform = e.target.value as VideoTransformOptions;
     let currentDevice = selectedDevice;
 
     if (isLoading || currentDevice === undefined) {
@@ -83,7 +83,7 @@ export const VideoTransformDropdown: React.FC<Props> = ({
       // Select the newly created device from the above logic as the video input device.
       await meetingManager.startVideoInputDevice(currentDevice);
       // Update the current selected transform (shared via AppState).
-      setActiveVideoTransformOption(selectedTransform);
+      setVideoTransformOption(selectedTransform);
     } catch (e) {
       console.error('Error trying to apply', selectTransform, e);
     } finally {
@@ -96,7 +96,7 @@ export const VideoTransformDropdown: React.FC<Props> = ({
       field={Select}
       options={options}
       onChange={selectTransform}
-      value={activeVideoTransformOption}
+      value={videoTransformOption}
       label={label}
     />
   );

--- a/apps/meeting/src/components/MeetingControls/VideoInputTransformControl.tsx
+++ b/apps/meeting/src/components/MeetingControls/VideoInputTransformControl.tsx
@@ -48,7 +48,7 @@ const VideoInputTransformControl: React.FC<Props> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [dropdownWithVideoTransformOptions, setDropdownWithVideoTransformOptions] = useState<ReactNode[] | null>(null);
   const videoDevices: DeviceType[] = useMemoCompare(devices, (prev: DeviceType[] | undefined, next: DeviceType[] | undefined): boolean => isEqual(prev, next));
-  const { backgroundReplacementOption, setBackgroundReplacementOption, replacementOptionsList, activeVideoTransformOption, setActiveVideoTransformOption } = useAppState();
+  const { backgroundReplacementOption, setBackgroundReplacementOption, replacementOptionsList, videoTransformOption, setVideoTransformOption } = useAppState();
 
   useEffect(() => {
     maybeResetDeviceToIntrinsic();
@@ -60,7 +60,7 @@ const VideoInputTransformControl: React.FC<Props> = ({
   const maybeResetDeviceToIntrinsic = async () => {
     try {
       if (
-        activeVideoTransformOption === VideoTransformOptions.None &&
+        videoTransformOption === VideoTransformOptions.None &&
         isVideoTransformDevice(selectedDevice)
       ) {
         const intrinsicDevice = await selectedDevice.intrinsicDevice();
@@ -91,7 +91,7 @@ const VideoInputTransformControl: React.FC<Props> = ({
         await current.stop();
         current = intrinsicDevice;
         // Switch to background blur device if old selection was background replacement otherwise switch to default intrinsic device.
-        if (activeVideoTransformOption === VideoTransformOptions.Replacement) {
+        if (videoTransformOption === VideoTransformOptions.Replacement) {
           current = await createBackgroundBlurDevice(current) as VideoTransformDevice;
           logger.info(`Video filter was turned on - video transform device: ${JSON.stringify(current)}`);
         } else {
@@ -108,8 +108,8 @@ const VideoInputTransformControl: React.FC<Props> = ({
       }
 
       // Update the current selected transform.
-      setActiveVideoTransformOption((activeVideoTransformOption) =>
-        activeVideoTransformOption === VideoTransformOptions.Blur
+      setVideoTransformOption((videoTransformOption) =>
+        videoTransformOption === VideoTransformOptions.Blur
           ? VideoTransformOptions.None
           : VideoTransformOptions.Blur
       );
@@ -139,7 +139,7 @@ const VideoInputTransformControl: React.FC<Props> = ({
         await current.stop();
         current = intrinsicDevice;
         // Switch to background replacement device if old selection was background blur otherwise switch to default intrinsic device.
-        if (activeVideoTransformOption === VideoTransformOptions.Blur) {
+        if (videoTransformOption === VideoTransformOptions.Blur) {
           current = await createBackgroundReplacementDevice(current) as VideoTransformDevice;
           logger.info(`Video filter turned on - selecting video transform device: ${JSON.stringify(current)}`);
         } else {
@@ -156,8 +156,8 @@ const VideoInputTransformControl: React.FC<Props> = ({
       }
 
       // Update the current selected transform.
-      setActiveVideoTransformOption((activeVideoTransformOption) =>
-        activeVideoTransformOption === VideoTransformOptions.Replacement
+      setVideoTransformOption((videoTransformOption) =>
+        videoTransformOption === VideoTransformOptions.Replacement
           ? VideoTransformOptions.None
           : VideoTransformOptions.Replacement
       );
@@ -236,7 +236,7 @@ const VideoInputTransformControl: React.FC<Props> = ({
         const videoTransformOptions: ReactNode = (
           <PopOverItem
             key="backgroundBlurFilter"
-            checked={activeVideoTransformOption === VideoTransformOptions.Blur}
+            checked={videoTransformOption === VideoTransformOptions.Blur}
             disabled={isLoading}
             onClick={toggleBackgroundBlur}
           >
@@ -255,7 +255,7 @@ const VideoInputTransformControl: React.FC<Props> = ({
         const videoTransformOptions: ReactNode = (
           <PopOverItem
             key="backgroundReplacementFilter"
-            checked={activeVideoTransformOption === VideoTransformOptions.Replacement}
+            checked={videoTransformOption === VideoTransformOptions.Replacement}
             disabled={isLoading}
             onClick={toggleBackgroundReplacement}
           >

--- a/apps/meeting/src/components/MeetingControls/VideoInputTransformControl.tsx
+++ b/apps/meeting/src/components/MeetingControls/VideoInputTransformControl.tsx
@@ -47,21 +47,22 @@ const VideoInputTransformControl: React.FC<Props> = ({
   const { isBackgroundReplacementSupported, createBackgroundReplacementDevice, changeBackgroundReplacementImage, backgroundReplacementProcessor } = useBackgroundReplacement();
   const [isLoading, setIsLoading] = useState(false);
   const [dropdownWithVideoTransformOptions, setDropdownWithVideoTransformOptions] = useState<ReactNode[] | null>(null);
-  const [activeVideoTransformOption, setActiveVideoTransformOption] = useState<string>(VideoTransformOptions.None);
   const videoDevices: DeviceType[] = useMemoCompare(devices, (prev: DeviceType[] | undefined, next: DeviceType[] | undefined): boolean => isEqual(prev, next));
-  const { backgroundReplacementOption, setBackgroundReplacementOption, replacementOptionsList } = useAppState();
+  const { backgroundReplacementOption, setBackgroundReplacementOption, replacementOptionsList, activeVideoTransformOption, setActiveVideoTransformOption } = useAppState();
 
   useEffect(() => {
-    resetDeviceToIntrinsic();
+    maybeResetDeviceToIntrinsic();
   }, []);
 
-  // Reset the video input to intrinsic if current video input is a transform device because this component
-  // does not know if blur or replacement was selected. This depends on how the demo is set up.
-  // TODO: use a hook in the appState to track whether blur or replacement was selected before this component mounts,
-  // or maintain the state of `activeVideoTransformOption` in `MeetingManager`.
-  const resetDeviceToIntrinsic = async () => {
+  // The selected transform (blur/replacement/none) is tracked in AppState, so if a
+  // transform was chosen on the device-setup page before this control mounted, keep
+  // it applied. Only reset to the intrinsic device when no transform was selected.
+  const maybeResetDeviceToIntrinsic = async () => {
     try {
-      if (isVideoTransformDevice(selectedDevice)) {
+      if (
+        activeVideoTransformOption === VideoTransformOptions.None &&
+        isVideoTransformDevice(selectedDevice)
+      ) {
         const intrinsicDevice = await selectedDevice.intrinsicDevice();
         await meetingManager.selectVideoInputDevice(intrinsicDevice);
       }

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -41,8 +41,8 @@ interface AppStateValue {
   enableMaxContentShares: boolean;
   /** The video transform (None/Blur/Replacement) selected before joining, so the
    * in-meeting control can re-apply it instead of resetting to the plain device. */
-  activeVideoTransformOption: string;
-  setActiveVideoTransformOption: React.Dispatch<React.SetStateAction<string>>;
+  videoTransformOption: VideoTransformOptions;
+  setVideoTransformOption: React.Dispatch<React.SetStateAction<VideoTransformOptions>>;
   toggleTheme: () => void;
   toggleVoiceFocusDesired: () => void;
   setIsVoiceFocusEnabled: (enabled: boolean) => void;
@@ -104,7 +104,7 @@ export function AppStateProvider({ children }: Props) {
     ReplacementOptions.Blue
   );
   const [enableMaxContentShares, setEnableMaxContentShares] = useState(false);
-  const [activeVideoTransformOption, setActiveVideoTransformOption] = useState<string>(
+  const [videoTransformOption, setVideoTransformOption] = useState<VideoTransformOptions>(
     VideoTransformOptions.None
   );
 
@@ -225,8 +225,8 @@ export function AppStateProvider({ children }: Props) {
     replacementOptionsList,
     enableMaxContentShares,
     toggleMaxContentShares,
-    activeVideoTransformOption,
-    setActiveVideoTransformOption,
+    videoTransformOption,
+    setVideoTransformOption,
   };
 
   return <AppStateContext.Provider value={providerValue}>{children}</AppStateContext.Provider>;

--- a/apps/meeting/src/providers/AppStateProvider.tsx
+++ b/apps/meeting/src/providers/AppStateProvider.tsx
@@ -7,6 +7,7 @@ import {
   MeetingMode,
   Layout,
   VideoFiltersCpuUtilization,
+  VideoTransformOptions,
   ReplacementOptions,
   ReplacementType,
   ReplacementDropdownOptionType,
@@ -38,6 +39,10 @@ interface AppStateValue {
   backgroundReplacementOption: ReplacementOptions;
   replacementOptionsList: ReplacementDropdownOptionType[];
   enableMaxContentShares: boolean;
+  /** The video transform (None/Blur/Replacement) selected before joining, so the
+   * in-meeting control can re-apply it instead of resetting to the plain device. */
+  activeVideoTransformOption: string;
+  setActiveVideoTransformOption: React.Dispatch<React.SetStateAction<string>>;
   toggleTheme: () => void;
   toggleVoiceFocusDesired: () => void;
   setIsVoiceFocusEnabled: (enabled: boolean) => void;
@@ -99,6 +104,9 @@ export function AppStateProvider({ children }: Props) {
     ReplacementOptions.Blue
   );
   const [enableMaxContentShares, setEnableMaxContentShares] = useState(false);
+  const [activeVideoTransformOption, setActiveVideoTransformOption] = useState<string>(
+    VideoTransformOptions.None
+  );
 
   const replacementOptionsList: ReplacementDropdownOptionType[] = [
     {
@@ -217,6 +225,8 @@ export function AppStateProvider({ children }: Props) {
     replacementOptionsList,
     enableMaxContentShares,
     toggleMaxContentShares,
+    activeVideoTransformOption,
+    setActiveVideoTransformOption,
   };
 
   return <AppStateContext.Provider value={providerValue}>{children}</AppStateContext.Provider>;

--- a/apps/meeting/src/types/index.ts
+++ b/apps/meeting/src/types/index.ts
@@ -56,11 +56,11 @@ export const VideoFiltersCpuUtilization = {
 };
 
 // Video Transform Options
-export const VideoTransformOptions = {
-  None: 'None',
-  Blur: 'Background Blur',
-  Replacement: 'Background Replacement',
-};
+export enum VideoTransformOptions {
+  None = 'None',
+  Blur = 'Background Blur',
+  Replacement = 'Background Replacement',
+}
 
 export type VideoTransformDropdownOptionType = {
   label: string;


### PR DESCRIPTION
  ## What
  Persist the background video transform (Blur/Replacement) chosen on the
  device-setup page so it remains applied after joining the meeting.
  
  ## Why
  The in-meeting VideoInputTransformControl reset the video input to the plain
  camera on mount because it had no knowledge of what was selected earlier (this
  was an explicit TODO in the code). As a result, a filter chosen during device
  setup was silently lost on join.
  
  ## How
  - Add `activeVideoTransformOption` to AppStateProvider as a shared source of truth.
  - VideoTransformDropdown (device page) reads/writes it instead of local state.
  - VideoInputTransformControl (in-meeting) reads it and only resets to the
    intrinsic device when no transform is selected.
  
  ## Testing
  - `npm run build:fast` passes.
  - Manually verified Blur and Replacement now persist from setup into the meeting;
    selecting None is unchanged.
  
  ## Scope
  Demo app only (`apps/meeting`). No changes to the component library or JS SDK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.